### PR TITLE
redhat: use %initsystem check that works when chrooted

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -49,7 +49,7 @@
 
 #### Check for systemd or init.d (upstart)
 # Check for init.d (upstart) as used in CentOS 6 or systemd (ie CentOS 7)
-%{expand: %%global initsystem %(if [[ `/sbin/init --version 2> /dev/null` =~ upstart ]]; then echo upstart; elif [[ `systemctl` =~ -\.mount ]]; then echo systemd; fi)}
+%{expand: %%global initsystem %(if [[ `/sbin/init --version 2> /dev/null` =~ upstart ]]; then echo upstart; elif [[ `file /sbin/init` =~ "symbolic link to \`../lib/systemd/systemd'" ]]; then echo systemd; fi)}
 #
 # If init system is systemd, then always disable watchfrr
 #


### PR DESCRIPTION
`systemctl' returns different, non-useful output while in a chroot.
Switch to checking if /sbin/init is a symlink to the systemd binary.
With this change the build works in a mock chroot.

Signed-off-by: Silas McCroskey <smccroskey@cumulusnetworks.com>