### PR TITLE
Fix for pcep counters show with null session

### DIFF
--- a/pathd/path_pcep_lib.c
+++ b/pathd/path_pcep_lib.c
@@ -224,8 +224,10 @@ void pcep_lib_parse_capabilities(struct pcep_message *msg,
 
 struct counters_group *pcep_lib_copy_counters(pcep_session *sess)
 {
-	assert(NULL != sess);
-	assert(NULL != sess->pcep_session_counters);
+	if( !sess || !sess->pcep_session_counters) {
+		return NULL;
+	}
+
 	return copy_counter_group(sess->pcep_session_counters);
 }
 
@@ -560,7 +562,7 @@ void free_counter_subgroup(struct counters_subgroup *subgroup)
 {
 	int i;
 	if (NULL == subgroup)
-		return NULL;
+		return;
 	for (i = 0; i <= subgroup->num_counters; i++)
 		free_counter(subgroup->counters[i]);
 	XFREE(MTYPE_PCEP, subgroup);
@@ -569,6 +571,6 @@ void free_counter_subgroup(struct counters_subgroup *subgroup)
 void free_counter(struct counter *counter)
 {
 	if (NULL == counter)
-		return NULL;
+		return;
 	XFREE(MTYPE_PCEP, counter);
 }


### PR DESCRIPTION
Fix for pcep counters show with null session

- also fixed a few minor compilation warnings