### PR TITLE
New config parameter (msd) in pcc configuration

### DIFF
--- a/pathd/path_pcep.c
+++ b/pathd/path_pcep.c
@@ -300,18 +300,21 @@ DEFUN(show_pcep_counters, show_pcep_counters_cmd, "show pcep counters",
 }
 
 DEFUN_NOSH(pcep_cli_pcc, pcep_cli_pcc_cmd,
-	   "pcc <ip A.B.C.D | ipv6 X:X::X:X> [port (1024-65535)]",
+	   "pcc <ip A.B.C.D | ipv6 X:X::X:X> [port (1024-65535)] [msd (1-16)]",
 	   "PCC configuration\n"
 	   "PCC source ip\n"
 	   "PCC source IPv4 address\n"
 	   "PCC source ip\n"
 	   "PCC source IPv6 address\n"
 	   "PCC source port\n"
-	   "PCC source port value\n")
+	   "PCC source port value\n"
+	   "PCC maximum SID depth \n"
+	   "PCC maximum SID depth value\n")
 {
 
 	struct ipaddr pcc_addr;
 	uint32_t pcc_port = PCEP_DEFAULT_PORT;
+	uint32_t pcc_msd = PCC_DEFAULT_MSD;
 	struct pcc_opts *opts, *opts_copy;
 	int i = 1;
 
@@ -351,6 +354,16 @@ DEFUN_NOSH(pcep_cli_pcc, pcep_cli_pcc_cmd,
 			i++;
 			continue;
 		}
+		if (strcmp("msd", argv[i]->arg) == 0) {
+			i++;
+			if (i >= argc)
+				return CMD_ERR_NO_MATCH;
+			pcc_msd = atoi(argv[i]->arg);
+			if (pcc_msd <= 0 || pcc_msd >= 16)
+				return CMD_ERR_INCOMPLETE;
+			i++;
+			continue;
+		}
 	}
 
 	opts = XCALLOC(MTYPE_PCEP, sizeof(*opts));
@@ -362,6 +375,7 @@ DEFUN_NOSH(pcep_cli_pcc, pcep_cli_pcc_cmd,
 		opts->addr.ipaddr_v4.s_addr = pcc_addr.ipaddr_v4.s_addr;
 	}
 	opts->port = pcc_port;
+  opts->msd = pcc_msd;
 
 	if (pcep_ctrl_update_pcc_options(pcep_g->fpt, opts))
 		return CMD_WARNING;
@@ -592,6 +606,9 @@ int pcep_cli_pcc_config_write(struct vty *vty)
 		if (pcep_g->pcc_opts->port != PCEP_DEFAULT_PORT)
 			csnprintfrr(buff, sizeof(buff), " port %d",
 				    pcep_g->pcc_opts->port);
+		if (pcep_g->pcc_opts->msd != PCC_DEFAULT_MSD)
+			csnprintfrr(buff, sizeof(buff), " msd %d",
+				    pcep_g->pcc_opts->msd);
 		vty_out(vty, "pcc%s\n", buff);
 		buff[0] = 0;
 		lines++;

--- a/pathd/path_pcep.h
+++ b/pathd/path_pcep.h
@@ -28,6 +28,7 @@
 #include "pathd/pathd.h"
 #include "pathd/path_pcep_memory.h"
 
+#define PCC_DEFAULT_MSD 4
 #define PCEP_DEFAULT_PORT 4189
 #define MAX_PCC 1
 #define MAX_TAG_SIZE 50
@@ -88,6 +89,7 @@ struct pce_opts {
 struct pcc_opts {
 	struct ipaddr addr;
 	short port;
+	short msd;
 };
 
 struct lsp_nb_key {

--- a/pathd/path_pcep_lib.c
+++ b/pathd/path_pcep_lib.c
@@ -108,6 +108,9 @@ pcep_session *pcep_lib_connect(struct pcc_opts *pcc_opts,
 	config->pcep_msg_versioning->draft_ietf_pce_segment_routing_07 =
 		pce_opts->draft07;
 
+	config->max_sid_depth =
+		pcc_opts->msd;
+
 	if (IS_IPADDR_V6(&pce_opts->addr)) {
 		sess = connect_pce_ipv6(config, &pce_opts->addr.ipaddr_v6);
 	} else {

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1756,14 +1756,16 @@ DEFUNSH(VTYSH_PATHD, te_path_sr_policy, te_path_sr_policy_cmd,
 }
 
 DEFUNSH(VTYSH_PATHD, pcep_cli_pcc, pcep_cli_pcc_cmd,
-	"pcc [<ip A.B.C.D | ipv6 X:X::X:X>] [port (1024-65535)]",
+	"pcc <ip A.B.C.D | ipv6 X:X::X:X> [port (1024-65535)] [msd (1-16)]",
 	"PCC configuration\n"
 	"PCC source ip\n"
 	"PCC source IPv4 address\n"
 	"PCC source ip\n"
 	"PCC source IPv6 address\n"
 	"PCC source port\n"
-	"PCC source port value\n")
+	"PCC source port value\n"
+	"PCC maximum SID depth \n"
+	"PCC maximum SID depth value\n")
 {
 	vty->node = PCC_NODE;
 	return CMD_SUCCESS;


### PR DESCRIPTION
Now MSD (Maximum SID Depth) is not sended to remote PCE in open message, fix that taking value from configuration even the ideally feature is getting from isis (which should be a future fix).

Both PCE tested (Cisco and ODL) requires flag `sr-draft07` in pce configuration for the MSD value to be processed.

It's been tested 
1. In cisco it's been checked with `show pce ipv4 peer detail` 
2. In ODL with karaf log (`log:set DEBUG`) 