### PR TITLE
Reject unsupported PcInitate PCEP messages

### DIFF
--- a/pathd/path_pcep_lib.c
+++ b/pathd/path_pcep_lib.c
@@ -156,6 +156,11 @@ struct pcep_message *pcep_lib_format_request(uint32_t reqid, struct ipaddr *src,
 	}
 }
 
+struct pcep_message *pcep_lib_reject_message(int error_type, int error_value)
+{
+	return pcep_msg_create_error(error_type, error_value);
+}
+
 struct path *pcep_lib_parse_path(struct pcep_message *msg)
 {
 	struct path *path;

--- a/pathd/path_pcep_lib.h
+++ b/pathd/path_pcep_lib.h
@@ -32,6 +32,7 @@ void pcep_lib_disconnect(pcep_session *sess);
 struct pcep_message *pcep_lib_format_report(struct path *path);
 struct pcep_message *pcep_lib_format_request(uint32_t reqid, struct ipaddr *src,
 					     struct ipaddr *dst);
+struct pcep_message *pcep_lib_reject_message(int error_type, int error_value);
 struct path *pcep_lib_parse_path(struct pcep_message *msg);
 void pcep_lib_parse_capabilities(struct pcep_message *msg,
 				 struct pcep_caps *caps);

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -440,8 +440,17 @@ void handle_pcep_lsp_initiate(struct ctrl_state *ctrl_state,
 			      struct pcc_state *pcc_state,
 			      struct pcep_message *msg)
 {
+	struct pcep_message *error;
+
 	PCEP_DEBUG("%s Received LSP initiate, not supported yet",
 		   pcc_state->tag);
+
+	/* TODO when we support both PCC and PCE initiated sessions,
+	 *      we should first check the session type before
+	 *      rejecting this message. */
+	error = pcep_lib_reject_message(PCEP_ERRT_INVALID_OPERATION,
+					PCEP_ERRV_LSP_NOT_PCE_INITIATED);
+	send_pcep_message(ctrl_state, pcc_state, error);
 }
 
 void handle_pcep_comp_reply(struct ctrl_state *ctrl_state,


### PR DESCRIPTION
- They should be rejected if the PCEP session is PCC initiated,
  since they are only supported for PCE initiated PCEP sessions.