### PR TITLE
Delete candidate when segment list name is empty

### DIFF
--- a/pathd/path_pcep_nb.c
+++ b/pathd/path_pcep_nb.c
@@ -284,9 +284,9 @@ int path_nb_update_path(struct path *path)
 	char *segment_list_name = NULL;
 	struct nb_config *config = nb_config_dup(running_config);
 
+	path_nb_delete_candidate_segment_list(config, &path->nbkey,
+					      path->originator);
 	if (path->first_hop != NULL) {
-		path_nb_delete_candidate_segment_list(config, &path->nbkey,
-		                                      path->originator);
 
 		snprintf(segment_list_name_buff, sizeof(segment_list_name_buff),
 			 "%s-%u", path->name, path->plsp_id);


### PR DESCRIPTION
If the PCE detect that a link part of the lsp has been lost ( down, etc) then sends a PcUpd to the PCC with the new status that will be end up in an inactive sr policy


Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>