### PR TITLE
bgpd: do not unregister for prefix nexthop updates if nh exists

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -87,6 +87,19 @@ struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
 	return bnc;
 }
 
+bool bnc_existing_for_prefix(struct bgp_nexthop_cache *bnc)
+{
+	struct bgp_nexthop_cache *bnc_tmp;
+
+	RB_FOREACH (bnc_tmp, bgp_nexthop_cache_head, bnc->tree) {
+		if (bnc_tmp == bnc)
+			continue;
+		if (prefix_cmp(&bnc->prefix, &bnc_tmp->prefix) == 0)
+			return true;
+	}
+	return false;
+}
+
 void bnc_free(struct bgp_nexthop_cache *bnc)
 {
 	bnc_nexthop_free(bnc);

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -114,6 +114,7 @@ extern bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 extern struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
 					 struct prefix *prefix,
 					 uint32_t srte_color);
+extern bool bnc_existing_for_prefix(struct bgp_nexthop_cache *bnc);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern struct bgp_nexthop_cache *bnc_find(struct bgp_nexthop_cache_head *tree,
 					  struct prefix *prefix,

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -76,8 +76,11 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 				   bnc_str(bnc, buf, PREFIX2STR_BUFFER),
 				   bnc->srte_color, bnc->bgp->name_pretty);
 		}
-		unregister_zebra_rnh(bnc,
-				     CHECK_FLAG(bnc->flags, BGP_STATIC_ROUTE));
+		/* only unregister if this is the last nh for this prefix*/
+		if (!bnc_existing_for_prefix(bnc))
+			unregister_zebra_rnh(bnc,
+					     CHECK_FLAG(bnc->flags,
+							BGP_STATIC_ROUTE));
 		bnc_free(bnc);
 	}
 }


### PR DESCRIPTION
since the addition of srte_color to the comparison for bgp nexthops
it is possible to have several nexthops per prefix but since zebra
only stores a per prefix registration we should not unregister for
nh notifications for a prefix until all the nexthops for that prefix
have been deleted. Otherwise we can get into a deadlock situation
where BGP thinks we have registered but we have unregistered from zebra.

Signed-off-by: Pat Ruddy <pat@voltanet.io>