### PR TITLE
pathd: pcep module: Add support for IPv6 router-id

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1050,23 +1050,34 @@ Many routing protocols require a router-id to be configured. To have a
 consistent router-id across all daemons, the following commands are available
 to configure and display the router-id:
 
-.. index:: [no] router-id A.B.C.D
-.. clicmd:: [no] router-id A.B.C.D
+.. index:: [no] [ip] router-id A.B.C.D
+.. clicmd:: [no] [ip] router-id A.B.C.D
 
    Allow entering of the router-id.  This command also works under the
-   vrf subnode, to allow router-id's per vrf. 
+   vrf subnode, to allow router-id's per vrf.
 
-.. index:: [no] router-id A.B.C.D vrf NAME
-.. clicmd:: [no] router-id A.B.C.D vrf NAME
+.. index:: [no] [ip] router-id A.B.C.D vrf NAME
+.. clicmd:: [no] [ip] router-id A.B.C.D vrf NAME
 
    Configure the router-id of this router from the configure NODE.
    A show run of this command will display the router-id command
    under the vrf sub node.  This command is deprecated and will
    be removed at some point in time in the future.
- 
-.. index:: show router-id [vrf NAME]
-.. clicmd:: show router-id [vrf NAME]
+
+.. index:: show [ip] router-id [vrf NAME]
+.. clicmd:: show [ip] router-id [vrf NAME]
 
    Display the user configured router-id.
 
+For protocols requiring an IPv6 router-id, the following commands are available:
 
+.. index:: [no] ipv6 router-id X:X::X:X
+.. clicmd:: [no] ipv6 router-id X:X::X:X
+
+   Configure the IPv6 router-id of this router. Like its IPv4 counterpart,
+   this command works under the vrf subnode, to allow router-id's per vrf.
+
+.. index:: show ipv6 router-id [vrf NAME]
+.. clicmd:: show ipv6 router-id [vrf NAME]
+
+   Display the user configured IPv6 router-id.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1050,11 +1050,20 @@ Many routing protocols require a router-id to be configured. To have a
 consistent router-id across all daemons, the following commands are available
 to configure and display the router-id:
 
-.. index:: [no] router-id A.B.C.D [vrf NAME]
-.. clicmd:: [no] router-id A.B.C.D [vrf NAME]
+.. index:: [no] router-id A.B.C.D
+.. clicmd:: [no] router-id A.B.C.D
 
-   Configure the router-id of this router.
+   Allow entering of the router-id.  This command also works under the
+   vrf subnode, to allow router-id's per vrf. 
 
+.. index:: [no] router-id A.B.C.D vrf NAME
+.. clicmd:: [no] router-id A.B.C.D vrf NAME
+
+   Configure the router-id of this router from the configure NODE.
+   A show run of this command will display the router-id command
+   under the vrf sub node.  This command is deprecated and will
+   be removed at some point in time in the future.
+ 
 .. index:: show router-id [vrf NAME]
 .. clicmd:: show router-id [vrf NAME]
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -437,7 +437,8 @@ void zclient_send_reg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 			   vrf_id);
 
 	/* We need router-id information. */
-	zebra_message_send(zclient, ZEBRA_ROUTER_ID_ADD, vrf_id);
+	zclient_send_router_id_update(zclient, ZEBRA_ROUTER_ID_ADD, AFI_IP,
+				      vrf_id);
 
 	/* We need interface information. */
 	zebra_message_send(zclient, ZEBRA_INTERFACE_ADD, vrf_id);
@@ -504,7 +505,8 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 			   vrf_id);
 
 	/* We need router-id information. */
-	zebra_message_send(zclient, ZEBRA_ROUTER_ID_DELETE, vrf_id);
+	zclient_send_router_id_update(zclient, ZEBRA_ROUTER_ID_DELETE, AFI_IP,
+				      vrf_id);
 
 	zebra_message_send(zclient, ZEBRA_INTERFACE_DELETE, vrf_id);
 
@@ -553,6 +555,18 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 				ZEBRA_REDISTRIBUTE_DEFAULT_DELETE, zclient, afi,
 				vrf_id);
 	}
+}
+
+int zclient_send_router_id_update(struct zclient *zclient,
+				  zebra_message_types_t type, afi_t afi,
+				  vrf_id_t vrf_id)
+{
+	struct stream *s = zclient->obuf;
+	stream_reset(s);
+	zclient_create_header(s, type, vrf_id);
+	stream_putw(s, afi);
+	stream_putw_at(s, 0, stream_get_endp(s));
+	return zclient_send_message(zclient);
 }
 
 /* Send request to zebra daemon to start or stop RA. */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -676,6 +676,9 @@ extern void zclient_send_vrf_label(struct zclient *zclient, vrf_id_t vrf_id,
 
 extern void zclient_send_reg_requests(struct zclient *, vrf_id_t);
 extern void zclient_send_dereg_requests(struct zclient *, vrf_id_t);
+extern int zclient_send_router_id_update(struct zclient *zclient,
+					 zebra_message_types_t type, afi_t afi,
+					 vrf_id_t vrf_id);
 
 extern void zclient_send_interface_radv_req(struct zclient *zclient,
 					    vrf_id_t vrf_id,

--- a/pathd/path_zebra.h
+++ b/pathd/path_zebra.h
@@ -19,6 +19,9 @@
 #ifndef _FRR_PATH_MPLS_H_
 #define _FRR_PATH_MPLS_H_
 
-bool get_inet_router_id(struct in_addr *router_id);
+#include <zebra.h>
+
+bool get_ipv4_router_id(struct in_addr *router_id);
+bool get_ipv6_router_id(struct in6_addr *router_id);
 
 #endif /* _FRR_PATH_MPLS_H_ */

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -416,12 +416,12 @@ int main(int argc, char **argv)
 	rib_init();
 	zebra_if_init();
 	zebra_debug_init();
-	router_id_cmd_init();
 
 	/*
 	 * Initialize NS( and implicitly the VRF module), and make kernel
 	 * routing socket. */
 	zebra_ns_init((const char *)vrf_default_name_configured);
+	router_id_cmd_init();
 	zebra_vty_init();
 	access_list_init();
 	prefix_list_init();

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -69,11 +69,10 @@ static int router_id_bad_address(struct connected *ifc)
 	return 0;
 }
 
-void router_id_get(struct prefix *p, vrf_id_t vrf_id)
+void router_id_get(struct prefix *p, struct zebra_vrf *zvrf)
 {
 	struct listnode *node;
 	struct connected *c;
-	struct zebra_vrf *zvrf = vrf_info_get(vrf_id);
 
 	p->u.prefix4.s_addr = INADDR_ANY;
 	p->family = AF_INET;
@@ -92,27 +91,18 @@ void router_id_get(struct prefix *p, vrf_id_t vrf_id)
 	}
 }
 
-static void router_id_set(struct prefix *p, vrf_id_t vrf_id)
+static void router_id_set(struct prefix *p, struct zebra_vrf *zvrf)
 {
 	struct prefix p2;
 	struct listnode *node;
 	struct zserv *client;
-	struct zebra_vrf *zvrf;
-
-	if (p->u.prefix4.s_addr == 0) /* unset */
-	{
-		zvrf = vrf_info_lookup(vrf_id);
-		if (!zvrf)
-			return;
-	} else /* set */
-		zvrf = vrf_info_get(vrf_id);
 
 	zvrf->rid_user_assigned.u.prefix4.s_addr = p->u.prefix4.s_addr;
 
-	router_id_get(&p2, vrf_id);
+	router_id_get(&p2, zvrf);
 
 	for (ALL_LIST_ELEMENTS_RO(zrouter.client_list, node, client))
-		zsend_router_id_update(client, &p2, vrf_id);
+		zsend_router_id_update(client, &p2, zvrf->vrf->vrf_id);
 }
 
 void router_id_add_address(struct connected *ifc)
@@ -127,7 +117,7 @@ void router_id_add_address(struct connected *ifc)
 	if (router_id_bad_address(ifc))
 		return;
 
-	router_id_get(&before, zvrf_id(zvrf));
+	router_id_get(&before, zvrf);
 
 	if (if_is_loopback(ifc->ifp))
 		l = zvrf->rid_lo_sorted_list;
@@ -137,7 +127,7 @@ void router_id_add_address(struct connected *ifc)
 	if (!router_id_find_node(l, ifc))
 		listnode_add_sort(l, ifc);
 
-	router_id_get(&after, zvrf_id(zvrf));
+	router_id_get(&after, zvrf);
 
 	if (prefix_same(&before, &after))
 		return;
@@ -159,7 +149,7 @@ void router_id_del_address(struct connected *ifc)
 	if (router_id_bad_address(ifc))
 		return;
 
-	router_id_get(&before, zvrf_id(zvrf));
+	router_id_get(&before, zvrf);
 
 	if (if_is_loopback(ifc->ifp))
 		l = zvrf->rid_lo_sorted_list;
@@ -169,7 +159,7 @@ void router_id_del_address(struct connected *ifc)
 	if ((c = router_id_find_node(l, ifc)))
 		listnode_delete(l, c);
 
-	router_id_get(&after, zvrf_id(zvrf));
+	router_id_get(&after, zvrf);
 
 	if (prefix_same(&before, &after))
 		return;
@@ -178,38 +168,30 @@ void router_id_del_address(struct connected *ifc)
 		zsend_router_id_update(client, &after, zvrf_id(zvrf));
 }
 
-void router_id_write(struct vty *vty)
+void router_id_write(struct vty *vty, struct zebra_vrf *zvrf)
 {
-	struct vrf *vrf;
-	struct zebra_vrf *zvrf;
+	char space[2];
 
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
-		if ((zvrf = vrf->info) != NULL)
-			if (zvrf->rid_user_assigned.u.prefix4.s_addr
-			    != INADDR_ANY) {
-				if (zvrf_id(zvrf) == VRF_DEFAULT)
-					vty_out(vty, "router-id %s\n",
-						inet_ntoa(
-							zvrf->rid_user_assigned
-								.u.prefix4));
-				else
-					vty_out(vty, "router-id %s vrf %s\n",
-						inet_ntoa(
-							zvrf->rid_user_assigned
-								.u.prefix4),
-						zvrf_name(zvrf));
-			}
+	memset(space, 0, sizeof(space));
+
+	if (zvrf_id(zvrf) != VRF_DEFAULT)
+		snprintf(space, sizeof(space), "%s", " ");
+
+	if (zvrf->rid_user_assigned.u.prefix4.s_addr != INADDR_ANY) {
+		vty_out(vty, "%srouter-id %s\n", space,
+			inet_ntoa(zvrf->rid_user_assigned.u.prefix4));
+	}
 }
 
 DEFUN (router_id,
        router_id_cmd,
-       "router-id A.B.C.D [vrf NAME]",
+       "router-id A.B.C.D vrf NAME",
        "Manually set the router-id\n"
-       "IP address to use for router-id\n"
-       VRF_CMD_HELP_STR)
+       "IP address to use for router-id\n" VRF_CMD_HELP_STR)
 {
 	int idx_ipv4 = 1;
 	int idx_name = 3;
+	struct zebra_vrf *zvrf;
 
 	struct prefix rid;
 	vrf_id_t vrf_id = VRF_DEFAULT;
@@ -224,23 +206,45 @@ DEFUN (router_id,
 	if (argc > 2)
 		VRF_GET_ID(vrf_id, argv[idx_name]->arg, false);
 
-	router_id_set(&rid, vrf_id);
+	zvrf = vrf_info_lookup(vrf_id);
+	router_id_set(&rid, zvrf);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (router_id_in_vrf,
+       router_id_in_vrf_cmd,
+       "router-id A.B.C.D",
+       "Manuall set the router-id\n"
+       "IP address to use for router-id\n")
+{
+	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+	int idx_ipv4 = 1;
+	struct prefix rid;
+
+	rid.u.prefix4.s_addr = inet_addr(argv[idx_ipv4]->arg);
+	if (!rid.u.prefix4.s_addr)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	rid.prefixlen = 32;
+	rid.family = AF_INET;
+
+	router_id_set(&rid, zvrf);
 
 	return CMD_SUCCESS;
 }
 
 DEFUN (no_router_id,
        no_router_id_cmd,
-       "no router-id [A.B.C.D [vrf NAME]]",
+       "no router-id [A.B.C.D vrf NAME]",
        NO_STR
        "Remove the manually configured router-id\n"
-       "IP address to use for router-id\n"
-       VRF_CMD_HELP_STR)
+       "IP address to use for router-id\n" VRF_CMD_HELP_STR)
 {
 	int idx_name = 4;
-
 	struct prefix rid;
 	vrf_id_t vrf_id = VRF_DEFAULT;
+	struct zebra_vrf *zvrf;
 
 	rid.u.prefix4.s_addr = 0;
 	rid.prefixlen = 0;
@@ -249,7 +253,28 @@ DEFUN (no_router_id,
 	if (argc > 3)
 		VRF_GET_ID(vrf_id, argv[idx_name]->arg, false);
 
-	router_id_set(&rid, vrf_id);
+	zvrf = vrf_info_get(vrf_id);
+	router_id_set(&rid, zvrf);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_router_id_in_vrf,
+       no_router_id_in_vrf_cmd,
+       "no router-id [A.B.C.D]",
+       NO_STR
+       "Remove the manually configured router-id\n"
+       "IP address to use for router-id\n")
+{
+	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
+
+	struct prefix rid;
+
+	rid.u.prefix4.s_addr = 0;
+	rid.prefixlen = 0;
+	rid.family = AF_INET;
+
+	router_id_set(&rid, zvrf);
 
 	return CMD_SUCCESS;
 }
@@ -298,6 +323,10 @@ void router_id_cmd_init(void)
 {
 	install_element(CONFIG_NODE, &router_id_cmd);
 	install_element(CONFIG_NODE, &no_router_id_cmd);
+	install_element(CONFIG_NODE, &router_id_in_vrf_cmd);
+	install_element(VRF_NODE, &router_id_in_vrf_cmd);
+	install_element(CONFIG_NODE, &no_router_id_in_vrf_cmd);
+	install_element(VRF_NODE, &no_router_id_in_vrf_cmd);
 	install_element(VIEW_NODE, &show_router_id_cmd);
 }
 

--- a/zebra/router-id.h
+++ b/zebra/router-id.h
@@ -39,7 +39,7 @@ extern void router_id_del_address(struct connected *c);
 extern void router_id_init(struct zebra_vrf *zvrf);
 extern void router_id_cmd_init(void);
 extern void router_id_write(struct vty *vty, struct zebra_vrf *zvrf);
-extern void router_id_get(struct prefix *p, struct zebra_vrf *zvrf);
+extern int router_id_get(afi_t afi, struct prefix *p, struct zebra_vrf *zvrf);
 
 #ifdef __cplusplus
 }

--- a/zebra/router-id.h
+++ b/zebra/router-id.h
@@ -34,12 +34,12 @@
 extern "C" {
 #endif
 
-extern void router_id_add_address(struct connected *);
-extern void router_id_del_address(struct connected *);
-extern void router_id_init(struct zebra_vrf *);
+extern void router_id_add_address(struct connected *c);
+extern void router_id_del_address(struct connected *c);
+extern void router_id_init(struct zebra_vrf *zvrf);
 extern void router_id_cmd_init(void);
-extern void router_id_write(struct vty *);
-extern void router_id_get(struct prefix *, vrf_id_t);
+extern void router_id_write(struct vty *vty, struct zebra_vrf *zvrf);
+extern void router_id_get(struct prefix *p, struct zebra_vrf *zvrf);
 
 #ifdef __cplusplus
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1890,7 +1890,7 @@ static void zread_router_id_add(ZAPI_HANDLER_ARGS)
 	/* Router-id information is needed. */
 	vrf_bitmap_set(client->ridinfo, zvrf_id(zvrf));
 
-	router_id_get(&p, zvrf_id(zvrf));
+	router_id_get(&p, zvrf);
 
 	zsend_router_id_update(client, &p, zvrf_id(zvrf));
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -905,17 +905,18 @@ void zsend_iptable_notify_owner(struct zebra_pbr_iptable *iptable,
 	zserv_send_message(client, s);
 }
 
-/* Router-id is updated. Send ZEBRA_ROUTER_ID_ADD to client. */
-int zsend_router_id_update(struct zserv *client, struct prefix *p,
+/* Router-id is updated. Send ZEBRA_ROUTER_ID_UPDATE to client. */
+int zsend_router_id_update(struct zserv *client, afi_t afi, struct prefix *p,
 			   vrf_id_t vrf_id)
 {
 	int blen;
+	struct stream *s;
 
 	/* Check this client need interface information. */
-	if (!vrf_bitmap_check(client->ridinfo, vrf_id))
+	if (!vrf_bitmap_check(client->ridinfo[afi], vrf_id))
 		return 0;
 
-	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	/* Message type. */
 	zclient_create_header(s, ZEBRA_ROUTER_ID_UPDATE, vrf_id);
@@ -1885,20 +1886,48 @@ stream_failure:
 /* Register zebra server router-id information.  Send current router-id */
 static void zread_router_id_add(ZAPI_HANDLER_ARGS)
 {
+	afi_t afi;
+
 	struct prefix p;
 
+	STREAM_GETW(msg, afi);
+
+	if (afi <= AFI_UNSPEC || afi >= AFI_MAX) {
+		zlog_warn(
+			"Invalid AFI %u while registering for router ID notifications",
+			afi);
+		goto stream_failure;
+	}
+
 	/* Router-id information is needed. */
-	vrf_bitmap_set(client->ridinfo, zvrf_id(zvrf));
+	vrf_bitmap_set(client->ridinfo[afi], zvrf_id(zvrf));
 
-	router_id_get(&p, zvrf);
+	router_id_get(afi, &p, zvrf);
 
-	zsend_router_id_update(client, &p, zvrf_id(zvrf));
+	zsend_router_id_update(client, afi, &p, zvrf_id(zvrf));
+
+stream_failure:
+	return;
 }
 
 /* Unregister zebra server router-id information. */
 static void zread_router_id_delete(ZAPI_HANDLER_ARGS)
 {
-	vrf_bitmap_unset(client->ridinfo, zvrf_id(zvrf));
+	afi_t afi;
+
+	STREAM_GETW(msg, afi);
+
+	if (afi <= AFI_UNSPEC || afi >= AFI_MAX) {
+		zlog_warn(
+			"Invalid AFI %u while unregistering from router ID notifications",
+			afi);
+		goto stream_failure;
+	}
+
+	vrf_bitmap_unset(client->ridinfo[afi], zvrf_id(zvrf));
+
+stream_failure:
+	return;
 }
 
 static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
@@ -1987,8 +2016,8 @@ static void zread_vrf_unregister(ZAPI_HANDLER_ARGS)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
 			vrf_bitmap_unset(client->redist[afi][i], zvrf_id(zvrf));
 		vrf_bitmap_unset(client->redist_default[afi], zvrf_id(zvrf));
+		vrf_bitmap_unset(client->ridinfo[afi], zvrf_id(zvrf));
 	}
-	vrf_bitmap_unset(client->ridinfo, zvrf_id(zvrf));
 }
 
 /*

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -68,8 +68,8 @@ extern int zsend_redistribute_route(int cmd, struct zserv *zclient,
 				    const struct prefix *src_p,
 				    const struct route_entry *re);
 
-extern int zsend_router_id_update(struct zserv *zclient, struct prefix *p,
-				  vrf_id_t vrf_id);
+extern int zsend_router_id_update(struct zserv *zclient, afi_t afi,
+				  struct prefix *p, vrf_id_t vrf_id);
 extern int zsend_interface_vrf_update(struct zserv *zclient,
 				      struct interface *ifp, vrf_id_t vrf_id);
 extern int zsend_interface_link_params(struct zserv *zclient,

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -544,6 +544,7 @@ static int vrf_config_write(struct vty *vty)
 
 
 		zebra_routemap_config_write_protocol(vty, zvrf);
+		router_id_write(vty, zvrf);
 
 		if (zvrf_id(zvrf) != VRF_DEFAULT)
 			vty_endframe(vty, " exit-vrf\n!\n");

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -92,6 +92,11 @@ struct zebra_vrf {
 	struct list *rid_all_sorted_list;
 	struct list *rid_lo_sorted_list;
 	struct prefix rid_user_assigned;
+	struct list _rid6_all_sorted_list;
+	struct list _rid6_lo_sorted_list;
+	struct list *rid6_all_sorted_list;
+	struct list *rid6_lo_sorted_list;
+	struct prefix rid6_user_assigned;
 
 	/*
 	 * Back pointer to the owning namespace.

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3434,9 +3434,6 @@ static int config_write_table(struct vty *vty)
 /* IPForwarding configuration write function. */
 static int config_write_forwarding(struct vty *vty)
 {
-	/* FIXME: Find better place for that. */
-	router_id_write(vty);
-
 	if (!ipforward())
 		vty_out(vty, "no ip forwarding\n");
 	if (!ipforward_ipv6())

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -628,8 +628,8 @@ static void zserv_client_free(struct zserv *client)
 		}
 
 		vrf_bitmap_free(client->redist_default[afi]);
+		vrf_bitmap_free(client->ridinfo[afi]);
 	}
-	vrf_bitmap_free(client->ridinfo);
 
 	/*
 	 * If any instance are graceful restart enabled,
@@ -750,8 +750,8 @@ static struct zserv *zserv_client_create(int sock)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
 			client->redist[afi][i] = vrf_bitmap_init();
 		client->redist_default[afi] = vrf_bitmap_init();
+		client->ridinfo[afi] = vrf_bitmap_init();
 	}
-	client->ridinfo = vrf_bitmap_init();
 
 	/* Add this client to linked list. */
 	frr_with_mutex(&client_mutex) {

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -135,7 +135,7 @@ struct zserv {
 	vrf_bitmap_t redist_default[AFI_MAX];
 
 	/* Router-id information. */
-	vrf_bitmap_t ridinfo;
+	vrf_bitmap_t ridinfo[AFI_MAX];
 
 	bool notify_owner;
 


### PR DESCRIPTION
This includes a backport of the pending PR for master: https://github.com/FRRouting/frr/pull/6483