### PR TITLE
Fix multi pce

### DIFF
--- a/pathd/path_pcep_controller.c
+++ b/pathd/path_pcep_controller.c
@@ -539,10 +539,7 @@ int pcep_thread_timer_handler(struct thread *thread)
 		break;
 	case TM_CALCULATE_BEST_PCE:
 		/* Previous best disconnect so new best should be synced */
-		if (!ctrl_state->pcc_count) {
-			ret = pcep_pcc_timer_update_best_pce(ctrl_state,
-							     pcc_id);
-		}
+		ret = pcep_pcc_timer_update_best_pce(ctrl_state, pcc_id);
 		break;
 	default:
 		flog_warn(EC_PATH_PCEP_RECOVERABLE_INTERNAL_ERROR,


### PR DESCRIPTION
1.- Restore timer proper functionality
2.- In the EV_SYNC_PATH handle use get_best_pce as it's already
  calculated either for adding pce's or for a new best after lost
current best.

Signed-off-by: Javier Garcia <javier.garcia@voltanet.io>