### PR TITLE
pathd: pcep: clear pcep-session vtysh command

### DIFF
--- a/pathd/path_pcep_controller.h
+++ b/pathd/path_pcep_controller.h
@@ -105,6 +105,7 @@ int pcep_ctrl_update_pcc_options(struct frr_pthread *fpt,
 int pcep_ctrl_update_pce_options(struct frr_pthread *fpt,
 				 struct pce_opts *opts);
 int pcep_ctrl_remove_pcc(struct frr_pthread *fpt, struct pce_opts *pce_opts);
+int pcep_ctrl_reset_pcc_session(struct frr_pthread *fpt, char *pce_name);
 int pcep_ctrl_pathd_event(struct frr_pthread *fpt,
 			  enum pcep_pathd_event_type type, struct path *path);
 int pcep_ctrl_sync_path(struct frr_pthread *fpt, int pcc_id, struct path *path);


### PR DESCRIPTION
- disconnect and connect again from one or all PCEs
- this does not affect the running-config

Signed-off-by: Brady Johnson <bradyallenjohnson@gmail.com>