### PR TITLE
Migrate bgp default originate route map match set topotato

### DIFF
--- a/tests/topotato/test_bgp_default-originate_route-map_match_set.py
+++ b/tests/topotato/test_bgp_default-originate_route-map_match_set.py
@@ -1,0 +1,123 @@
+from topotato import *
+"""
+Test if default-originate works with match operations.
+And verify if set operations work as well.
+
+"""
+
+@topology_fixture()
+def allproto_topo(topo):
+  """
+  [ r1 ]
+    |
+  { s1 }
+    |
+  [ r2 ]
+  
+  """
+  topo.router("r1").lo_ip4.append("172.16.255.254/32")
+  topo.router("r1").iface_to("s1").ip4.append("192.168.255.1/24")
+  topo.router("r2").iface_to("s1").ip4.append("192.168.255.2/24")
+
+class Configs(FRRConfigs):
+  routers = ["r1", "r2"]
+    
+  zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   if router.name == 'r1'
+    interface lo
+     ip address {{ routers.r1.lo_ip4[0] }} 
+    !
+    ip route 192.168.13.0./24 Null0
+    !
+    #%   endif
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }} 
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+    
+  bgpd = """
+  #% block main
+    #%   if router.name == 'r2'
+    router bgp 65001
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} remote-as 65000
+      neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} timers 3 10
+      address-family ipv4 unicast
+        redistribute connected
+      exit-address-family
+    !
+    #%   elif router.name == 'r1'
+    router bgp 65000
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} remote-as 65001
+      neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} timers 3 10
+      address-family ipv4 unicast
+        redistribute connected
+          network 192.168.13.0/24 route-map internal
+          neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} default-originate route-map default
+      exit-address-family
+    !
+    bgp community-list standard default seq 5 permit 65000:1
+    !
+    route-map default permit 10
+      match community default
+      set metric 123
+      set as-path prepend 65000 65000 65000
+    !
+    route-map internal permit 10
+      set community 65000:1
+    !
+    #%   endif
+  #% endblock
+  """
+
+
+@config_fixture(Configs)
+def configs(config, allproto_topo):
+    return config
+
+@instance_fixture()
+def testenv(configs):
+    return FRRNetworkInstance(configs.topology, configs).prepare()
+  
+  
+class BGPDefaultOriginateRouteMapMatchSet(TestBase):
+    instancefn = testenv
+    
+    # Establish BGP connection  
+    @topotatofunc
+    def bgp_converge(self, topo, r1, r2):
+        expected = {
+            str(r1.ifaces[0].ip4[0].ip): {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        yield from AssertVtysh.make(
+            r2, "bgpd", f"show ip bgp neighbor {r1.ifaces[0].ip4[0].ip} json", maxwait=3.0, compare=expected
+        )
+            
+    @topotatofunc
+    def bgp_default_route_has_metric(self, topo, r1, r2):
+
+        expected = {
+            "paths": [
+                {
+                    "aspath": {"string": "65000 65000 65000 65000"},
+                    "metric": 123,
+                    "community": None,
+                }
+            ]
+        }
+        yield from AssertVtysh.make(
+            r2, "bgpd", f"show ip bgp 0.0.0.0/0 json", maxwait=5.0, compare=expected
+        )
+
+


### PR DESCRIPTION
Migrating test bgp default originate route map match set from topotests to topotato

**Test Output**

```
root@frrr:~/newfrr1/tests/topotato# ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v -x test_bgp_default-originate_route-map_match_set.py
================================================================================= topotato initialization ==================================================================================
---------------------------------------------------------------------------------- live log sessionstart -----------------------------------------------------------------------------------
DEBUG    topotato:topolinux.py:87 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:87 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:87 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:87 executable dumpcap found: /usr/bin/dumpcap
DEBUG    topotato:topolinux.py:87 executable ip found: /usr/sbin/ip
DEBUG    topotato:frr.py:124 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:139 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:171 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:183 zebra => zebra/zebra
DEBUG    topotato:frr.py:181 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:181 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:183 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:183 ripd => ripd/ripd
DEBUG    topotato:frr.py:183 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:183 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:183 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:183 isisd => isisd/isisd
DEBUG    topotato:frr.py:183 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:183 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:183 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:183 babeld => babeld/babeld
DEBUG    topotato:frr.py:183 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:183 pimd => pimd/pimd
DEBUG    topotato:frr.py:183 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:183 staticd => staticd/staticd
DEBUG    topotato:frr.py:183 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:183 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:183 pathd => pathd/pathd
DEBUG    topotato:frr.py:181 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:181 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:181 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:181 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:181 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:181 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:181 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:181 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:181 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:181 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:pretty.py:396 executable dot found: /usr/bin/dot
Warning: daemon 'pim6d' not enabled in configure, skipping
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/newfrr1/tests/topotato, configfile: pytest.ini
collecting ... ----------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------
DEBUG    topotato:pytestintegration.py:29 _topotato_makeitem(<Module test_bgp_default-originate_route-map_match_set.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:pytestintegration.py:29 _topotato_makeitem(<Module test_bgp_default-originate_route-map_match_set.py>, 'BGPDefaultOriginateRouteMapMatchSet', <class 'test_bgp_default-originate_route-map_match_set.BGPDefaultOriginateRouteMapMatchSet'>)
DEBUG    topotato:pytestintegration.py:29 _topotato_makeitem(<TopotatoInstance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f04cf40cac0>)
DEBUG    topotato:pytestintegration.py:29 _topotato_makeitem(<TopotatoInstance ()>, 'bgp_default_route_has_metric', <topotato.base.TopotatoWrapped object at 0x7f04cf40c880>)
DEBUG    topotato:base.py:552 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #103:r2/bgpd/vtysh "show ip bgp neighbor 192.168.255.1 json">
DEBUG    topotato:base.py:552 collect on: <TopotatoFunction bgp_default_route_has_metric> test: <AssertVtysh #119:r2/bgpd/vtysh "show ip bgp 0.0.0.0/0 json">
collected 4 items

test_bgp_default-originate_route-map_match_set.py::BGPDefaultOriginateRouteMapMatchSet::startup PASSED (0.94)                                                                        [ 25%]
test_bgp_default-originate_route-map_match_set.py::BGPDefaultOriginateRouteMapMatchSet::bgp_converge::#103:r2/bgpd/vtysh "show ip bgp neighbor 192::168::255::1 json" PASSED (1.50)  [ 50%]
test_bgp_default-originate_route-map_match_set.py::BGPDefaultOriginateRouteMapMatchSet::bgp_default_route_has_metric::#119:r2/bgpd/vtysh "show ip bgp 0::0::0::0/0 json" PASSED (2.90) [ 75%]
test_bgp_default-originate_route-map_match_set.py::BGPDefaultOriginateRouteMapMatchSet::shutdown PASSED (0.36)                                                                       [100%]

==================================================================================== 4 passed in 5.96s =====================================================================================
root@frrr:~/newfrr1/tests/topotato#
```
