### PR TITLE
topotato: test_bgp_set_aspath_replace.py

### DIFF
--- a/test_bgp_set_aspath_replace.py
+++ b/test_bgp_set_aspath_replace.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Nathan Mangar
+
+"""
+Test if `set as-path replace` is working correctly for route-maps.
+"""
+
+__topotests_file__ = "bgp_set_aspath_replace/test_bgp_set_aspath_replace.py"
+__topotests_gitrev__ = "77e3d82167b97a1ff4abe59d6e4f12086a61d9f9"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }--[ r3 ]
+      |       |
+    [ r2 ]--{ s2 }
+
+    """
+
+    topo.router("r3").lo_ip4.append("172.16.255.31/32")
+    topo.router("r3").lo_ip4.append("172.16.255.32/32")
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2", "r3"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   if router.name == 'r3'
+    interface lo
+     ip address {{ routers.r3.lo_ip4[0] }}
+     ip address {{ routers.r3.lo_ip4[0] }}
+    !
+    #%   endif
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }} 
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+  #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers 3 10
+     address-family ipv4 unicast
+      neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} route-map r2 in
+     exit-address-family
+    !
+    ip prefix-list p1 seq 5 permit {{ routers.r3.lo_ip4[0] }}
+    !
+    route-map r2 permit 10
+     match ip address prefix-list p1
+     set as-path replace 65003
+    route-map r2 permit 20
+     set as-path replace any
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers 3 10
+     neighbor {{ routers.r3.iface_to('s2').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r3.iface_to('s2').ip4[0].ip }} timers 3 10
+    !
+    #%   elif router.name == 'r3'
+    router bgp 65003
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} timers 3 10
+     address-family ipv4 unicast
+      redistribute connected
+     exit-address-family
+    !
+    #%   endif
+  #% endblock
+  """
+
+
+class BGPSetAspathReplace(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def bgp_converge(self, _, r1, r3):
+        expected = {
+            "routes": {
+                str(r3.lo_ip4[0]): [{"path": "65002 65001"}],
+                str(r3.lo_ip4[1]): [{"path": "65001 65001"}],
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp ipv4 unicast json",
+            maxwait=5.0,
+            compare=expected,
+        )


### PR DESCRIPTION
Signed-off-by: Nathan Mangar <nathan@thundergear.io>
Co-authored-by: Bruno Bernard <contact.brunobernard@gmail.com>

**Test Output** 

```
➜  basetato git:(bgp-set-aspath-replace) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_set_aspath_replace.py
================================================================================== topotato initialization ===================================================================================

----------------------------------------------------------------------------------- live log sessionstart ------------------------------------------------------------------------------------
DEBUG    topotato:topolinux.py:88 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:88 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:88 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:88 executable ip found: /usr/sbin/ip
DEBUG    topotato:frr.py:143 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:158 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:197 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:209 zebra => zebra/zebra
DEBUG    topotato:frr.py:207 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:207 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:209 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:209 ripd => ripd/ripd
DEBUG    topotato:frr.py:209 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:209 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:209 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:209 isisd => isisd/isisd
DEBUG    topotato:frr.py:209 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:209 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:209 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:209 babeld => babeld/babeld
DEBUG    topotato:frr.py:209 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:209 pimd => pimd/pimd
DEBUG    topotato:frr.py:209 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:209 staticd => staticd/staticd
DEBUG    topotato:frr.py:209 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:209 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:209 pathd => pathd/pathd
DEBUG    topotato:frr.py:207 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:207 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:207 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:207 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:207 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:207 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:pretty.py:351 executable dot found: /usr/bin/dot
Warning: daemon 'pim6d' not enabled in configure, skipping
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato, configfile: pytest.ini
collecting ... ------------------------------------------------------------------------------------ live log collection -------------------------------------------------------------------------------------
DEBUG    topotato:base.py:273 _topotato_makeitem(<Module test_bgp_set_aspath_replace.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:273 _topotato_makeitem(<Module test_bgp_set_aspath_replace.py>, 'BGPSetAspathReplace', <class 'test_bgp_set_aspath_replace.BGPSetAspathReplace'>)
DEBUG    topotato:base.py:273 _topotato_makeitem(<Instance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7fef28c4e610>)
DEBUG    topotato:base.py:675 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #103:r1/bgpd/vtysh[show bgp ipv4 unicast json]>
collected 3 items                                                                                                                                                                            

test_bgp_set_aspath_replace.py::BGPSetAspathReplace::startup 
--------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:324 <topotato.frr.FRRNetworkInstance object at 0x7fef29ca8e50> tempdir created: /tmp/tmpz8lt60o4
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fef29ca8e50> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpz8lt60o4/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fef29ca8e50> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmpz8lt60o4/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fef29ca8e50> temp-subdir for <RouterNS: 'r3'> created: /tmp/tmpz8lt60o4/r3
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fef29ca8e50> temp-subdir for <RouterNS: 'r2'> created: /tmp/tmpz8lt60o4/r2
PASSED (1.49)                                                                                                                                                                          [ 33%]
test_bgp_set_aspath_replace.py::BGPSetAspathReplace::bgp_converge:#103:r1/bgpd/vtysh[show bgp ipv4 unicast json] PASSED (4.60)                                                         [ 66%]
test_bgp_set_aspath_replace.py::BGPSetAspathReplace::shutdown Running as user "root" and group "root". This could be dangerous.
PASSED (1.08)                                                                                                            [100%]

===================================================================================== 3 passed in 8.34s ======================================================================================
```