### PR TITLE
topotato: test_bgp_sender_as_path_loop_detection.py

### DIFF
--- a/test_bgp_sender_as_path_loop_detection.py
+++ b/test_bgp_sender_as_path_loop_detection.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Nathan Mangar
+
+"""
+Test if neighbor <neighbor> sender-as-path-loop-detection
+command works as expeced.
+"""
+
+__topotests_file__ = (
+    "bgp_sender_as_path_loop_detection/test_bgp_sender-as-path-loop-detection.py"
+)
+__topotests_gitrev__ = "4953ca977f3a5de8109ee6353ad07f816ca1774c"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }--[ r3 ]
+      |       |
+    [ r2 ]--{ s2 }
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2", "r3"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   if router.name == 'r1'
+    interface lo
+     ip address {{ routers.r1.lo_ip4[0] }}
+    !
+    #%   endif
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }} 
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+  #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} remote-as 65002
+      neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers 3 10
+      address-family ipv4 unicast
+        neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} route-map prepend out
+        redistribute connected
+      exit-address-family
+      !
+    !
+    route-map prepend permit 10
+      set as-path prepend 65003
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} remote-as 65001
+      neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers 3 10
+      neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} solo
+      neighbor {{ routers.r3.iface_to('s1').ip4[0].ip }} remote-as 65003
+      neighbor {{ routers.r3.iface_to('s1').ip4[0].ip }} timers 3 10
+      neighbor {{ routers.r3.iface_to('s1').ip4[0].ip }} solo
+      neighbor {{ routers.r3.iface_to('s1').ip4[0].ip }} sender-as-path-loop-detection
+    !
+    #%   elif router.name == 'r3'
+    router bgp 65003
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} remote-as 65002
+      neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} timers 3 10
+    !
+    #%   endif
+  #% endblock
+  """
+
+
+class BGPSenderAspathLoopDetection(
+    TestBase, AutoFixture, topo=topology, configs=Configs
+):
+    @topotatofunc
+    def bgp_converge(self, _, r1, r2):
+        expected = {
+            str(r1.iface_to("s1").ip4[0].ip): {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show ip bgp neighbor {r1.iface_to('s1').ip4[0].ip} json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_has_route_from_r1(self, _, r1, r2):
+        expected = {
+            "paths": [
+                {
+                    "aspath": {
+                        "segments": [{"type": "as-sequence", "list": [65001, 65003]}],
+                        "length": 2,
+                    }
+                }
+            ]
+        }
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show ip bgp {r1.lo_ip4[0]} json",
+            maxwait=1.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_suppress_route_to_r3(self, _, r2, r3):
+        expected = {"totalPrefixCounter": 0}
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show ip bgp neighbor {r3.iface_to('s1').ip4[0].ip} advertised-routes json",
+            maxwait=2.0,
+            compare=expected,
+        )


### PR DESCRIPTION
Signed-off-by: Nathan Mangar <nathan@thundergear.io>
Co-authored-by: Bruno Bernard <contact.brunobernard@gmail.com>

**Test Output** 

```
➜  basetato4 git:(bgp-sender-as-path-loop-detection) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_sender_as_path_loop_detection.py
=============================================================================================== topotato initialization ===============================================================================================

------------------------------------------------------------------------------------------------ live log sessionstart ------------------------------------------------------------------------------------------------
DEBUG    topotato:topolinux.py:88 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:88 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:88 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:88 executable ip found: /usr/sbin/ip
DEBUG    topotato:frr.py:143 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:158 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:197 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:209 zebra => zebra/zebra
DEBUG    topotato:frr.py:207 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:207 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:209 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:209 ripd => ripd/ripd
DEBUG    topotato:frr.py:209 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:209 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:209 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:209 isisd => isisd/isisd
DEBUG    topotato:frr.py:209 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:209 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:209 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:209 babeld => babeld/babeld
DEBUG    topotato:frr.py:209 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:209 pimd => pimd/pimd
DEBUG    topotato:frr.py:209 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:209 staticd => staticd/staticd
DEBUG    topotato:frr.py:209 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:209 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:209 pathd => pathd/pathd
DEBUG    topotato:frr.py:207 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:207 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:207 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:207 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:207 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:207 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:pretty.py:351 executable dot found: /usr/bin/dot
Warning: daemon 'pim6d' not enabled in configure, skipping
================================================================================================= test session starts =================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... ------------------------------------------------------------------------------------------------- live log collection -------------------------------------------------------------------------------------------------
DEBUG    topotato:base.py:273 _topotato_makeitem(<Module test_bgp_sender_as_path_loop_detection.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:273 _topotato_makeitem(<Module test_bgp_sender_as_path_loop_detection.py>, 'BGPSenderAspathLoopDetection', <class 'test_bgp_sender_as_path_loop_detection.BGPSenderAspathLoopDetection'>)
DEBUG    topotato:base.py:273 _topotato_makeitem(<Instance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7fc4839d0520>)
DEBUG    topotato:base.py:273 _topotato_makeitem(<Instance ()>, 'bgp_has_route_from_r1', <topotato.base.TopotatoWrapped object at 0x7fc4839d05e0>)
DEBUG    topotato:base.py:273 _topotato_makeitem(<Instance ()>, 'bgp_suppress_route_to_r3', <topotato.base.TopotatoWrapped object at 0x7fc4839d0640>)
DEBUG    topotato:base.py:675 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #100:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json]>
DEBUG    topotato:base.py:675 collect on: <TopotatoFunction bgp_has_route_from_r1> test: <AssertVtysh #120:r2/bgpd/vtysh[show ip bgp 10.255.0.1/32 json]>
DEBUG    topotato:base.py:675 collect on: <TopotatoFunction bgp_suppress_route_to_r3> test: <AssertVtysh #131:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.3 advertised-routes json]>
collected 5 items                                                                                                                                                                                                     

test_bgp_sender_as_path_loop_detection.py::BGPSenderAspathLoopDetection::startup 
--------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:324 <topotato.frr.FRRNetworkInstance object at 0x7fc4839dafa0> tempdir created: /tmp/tmpje3aveku
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fc4839dafa0> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpje3aveku/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fc4839dafa0> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmpje3aveku/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fc4839dafa0> temp-subdir for <RouterNS: 'r3'> created: /tmp/tmpje3aveku/r3
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7fc4839dafa0> temp-subdir for <RouterNS: 'r2'> created: /tmp/tmpje3aveku/r2
PASSED (1.65)                                                                                                                                                                                                   [ 20%]
test_bgp_sender_as_path_loop_detection.py::BGPSenderAspathLoopDetection::bgp_converge:#100:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json] PASSED (3.90)                                                    [ 40%]
test_bgp_sender_as_path_loop_detection.py::BGPSenderAspathLoopDetection::bgp_has_route_from_r1:#120:r2/bgpd/vtysh[show ip bgp 10.255.0.1/32 json] PASSED (0.01)                                                 [ 60%]
test_bgp_sender_as_path_loop_detection.py::BGPSenderAspathLoopDetection::bgp_suppress_route_to_r3:#131:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.3 advertised-routes json] PASSED (0.01)                      [ 80%]
test_bgp_sender_as_path_loop_detection.py::BGPSenderAspathLoopDetection::shutdown Running as user "root" and group "root". This could be dangerous.
PASSED (1.19)                                                                                                                 [100%]

================================================================================================== 5 passed in 7.89s ==================================================================================================
```