### PR TITLE
topotato: test_bgp_extended_optional_parameters_length.py

### DIFF
--- a/test_bgp_extended_optional_parameters_length.py
+++ b/test_bgp_extended_optional_parameters_length.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Jugroo Jesvin Brian
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, unknown-option-value, wildcard-import, unused-argument, f-string-without-interpolation, too-few-public-methods, unused-wildcard-import
+
+"""
+Test if Extended Optional Parameters Length encoding format works
+if forced with a knob.
+https://datatracker.ietf.org/doc/html/rfc9072
+"""
+
+__topotests_file__ = "bgp_extended_optional_parameters_length/test_bgp_extended_optional_parameters_length.py"
+__topotests_gitrev__ = "bfe6156ab0f4ea00e399d3374b2131d88108ce14"
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+       |
+    { s1 }
+       |
+    [ r2 ]
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%  if router.name == 'r2'
+    interface lo
+        ip address {{ routers.r2.lo_ip4[0] }}
+    !
+    #%  endif
+    #%  for iface in router.ifaces
+    interface {{ iface.ifname }}
+        ip address {{ iface.ip4[0] }}
+    !
+    #%  endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+    #% block main
+    #%  if router.name == 'r2'
+    router bgp 65001
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} remote-as external
+      neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} extended-optional-parameters
+      address-family ipv4
+        redistribute connected
+      exit-address-family
+    #%   elif router.name == 'r1'
+    router bgp 65000
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} remote-as external
+      neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} extended-optional-parameters
+    !
+    #%   endif
+    #% endblock
+    """
+
+
+class BGPExtendedOptionalParametersLength(
+    TestBase, AutoFixture, topo=topology, configs=Configs
+):
+    @topotatofunc
+    def bgp_converge(self, _, r1, r2):
+        expected = {
+            "peers": {
+                str(r2.ifaces[0].ip4[0].ip): {
+                    "pfxRcd": 2,
+                    "pfxSnt": 2,
+                    "state": "Established",
+                    "peerState": "OK",
+                }
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp ipv4 unicast summary json",
+            maxwait=2.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def _bgp_extended_optional_parameters_length(self, _, r1, r2):
+        expected = {
+            str(r2.ifaces[0].ip4[0].ip): {"extendedOptionalParametersLength": True}
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp neighbor {r2.ifaces[0].ip4[0].ip} json",
+            maxwait=2.0,
+            compare=expected,
+        )

--- a/test_bgp_extended_optional_parameters_length.py
+++ b/test_bgp_extended_optional_parameters_length.py
@@ -51,7 +51,7 @@ class Configs(FRRConfigs):
     bgpd = """
     #% block main
     #%  if router.name == 'r2'
-    router bgp 65001
+    router bgp 65002
       no bgp ebgp-requires-policy
       neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} remote-as external
       neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} extended-optional-parameters
@@ -59,7 +59,7 @@ class Configs(FRRConfigs):
         redistribute connected
       exit-address-family
     #%   elif router.name == 'r1'
-    router bgp 65000
+    router bgp 65001
       no bgp ebgp-requires-policy
       neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} remote-as external
       neighbor {{ routers.r2.ifaces[0].ip4[0].ip }} extended-optional-parameters


### PR DESCRIPTION
**Test Output** 

```
➜  basetato4 git:(bgp-extended-optional-parameters-length) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_extended_optional_parameters_length.py
===================================================================================================== topotato initialization ======================================================================================================

------------------------------------------------------------------------------------------------------ live log sessionstart -------------------------------------------------------------------------------------------------------
DEBUG    topotato:topolinux.py:88 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:88 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:88 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:88 executable ip found: /usr/sbin/ip
DEBUG    topotato:frr.py:143 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:158 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:197 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:209 zebra => zebra/zebra
DEBUG    topotato:frr.py:207 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:207 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:209 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:209 ripd => ripd/ripd
DEBUG    topotato:frr.py:209 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:209 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:209 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:209 isisd => isisd/isisd
DEBUG    topotato:frr.py:209 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:209 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:209 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:209 babeld => babeld/babeld
DEBUG    topotato:frr.py:209 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:209 pimd => pimd/pimd
DEBUG    topotato:frr.py:209 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:209 staticd => staticd/staticd
DEBUG    topotato:frr.py:209 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:209 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:209 pathd => pathd/pathd
DEBUG    topotato:frr.py:207 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:207 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:207 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:207 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:207 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:207 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:pretty.py:351 executable dot found: /usr/bin/dot
Warning: daemon 'pim6d' not enabled in configure, skipping
======================================================================================================= test session starts ========================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... ------------------------------------------------------------------------------------------------------- live log collection --------------------------------------------------------------------------------------------------------
DEBUG    topotato:base.py:276 _topotato_makeitem(<Module test_bgp_extended_optional_parameters_length.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:276 _topotato_makeitem(<Module test_bgp_extended_optional_parameters_length.py>, 'BGPExtendedOptionalParametersLength', <class 'test_bgp_extended_optional_parameters_length.BGPExtendedOptionalParametersLength'>)
DEBUG    topotato:base.py:276 _topotato_makeitem(<Instance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f055465b2e0>)
DEBUG    topotato:base.py:276 _topotato_makeitem(<Instance ()>, '_bgp_extended_optional_parameters_length', <topotato.base.TopotatoWrapped object at 0x7f055465b3a0>)
DEBUG    topotato:base.py:683 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #87:r1/bgpd/vtysh[show bgp ipv4 unicast summary json]>
DEBUG    topotato:base.py:683 collect on: <TopotatoFunction _bgp_extended_optional_parameters_length> test: <AssertVtysh #100:r1/bgpd/vtysh[show bgp neighbor 10.101.0.2 json]>
collected 4 items                                                                                                                                                                                                                  

test_bgp_extended_optional_parameters_length.py::BGPExtendedOptionalParametersLength::startup 
---------------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:324 <topotato.frr.FRRNetworkInstance object at 0x7f0554666190> tempdir created: /tmp/tmpszfegry5
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f0554666190> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpszfegry5/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f0554666190> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmpszfegry5/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f0554666190> temp-subdir for <RouterNS: 'r2'> created: /tmp/tmpszfegry5/r2
PASSED (2.08)                                                                                                                                                                                                                [ 25%]
test_bgp_extended_optional_parameters_length.py::BGPExtendedOptionalParametersLength::bgp_converge:#87:r1/bgpd/vtysh[show bgp ipv4 unicast summary json] PASSED (1.50)                                                       [ 50%]
test_bgp_extended_optional_parameters_length.py::BGPExtendedOptionalParametersLength::_bgp_extended_optional_parameters_length:#100:r1/bgpd/vtysh[show bgp neighbor 10.101.0.2 json] PASSED (0.00)                           [ 75%]
test_bgp_extended_optional_parameters_length.py::BGPExtendedOptionalParametersLength::shutdown Running as user "root" and group "root". This could be dangerous.
PASSED (1.06)                                                                                                                 [100%]

======================================================================================================== 4 passed in 6.40s =========================================================================================================

```