### PR TITLE
topotato: test_disable_addpath_rx.py

### DIFF
--- a/test_disable_addpath_rx.py
+++ b/test_disable_addpath_rx.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Nathan Mangar
+
+"""
+Test if AddPath RX direction is not negotiated via AddPath capability.
+"""
+
+
+__topotests_file__ = "bgp_disable_addpath_rx/test_disable_addpath_rx.py"
+__topotests_gitrev__ = "e82b531df94b9fd7bc456df8a1b7c58f2770eff9"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }  [ r3 ]
+      |       |
+    [ r2 ]--{ s2 }
+              |
+            [ r4 ]
+    """
+
+    topo.router("r3").lo_ip4.append("172.16.16.254/32")
+    topo.router("r4").lo_ip4.append("172.16.16.254/32")
+    topo.router("r1").iface_to("s1").ip4.append("192.168.1.1/24")
+    topo.router("r2").iface_to("s1").ip4.append("192.168.1.2/24")
+    topo.router("r2").iface_to("s2").ip4.append("192.168.2.2/24")
+    topo.router("r3").iface_to("s2").ip4.append("192.168.2.3/24")
+    topo.router("r4").iface_to("s2").ip4.append("192.168.2.4/24")
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2", "r3", "r4"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   if router.name == 'r3'
+    interface lo
+     ip address {{ routers.r3.lo_ip4[0] }}
+    !
+    #%   elif router.name == 'r4'
+    interface lo
+     ip address {{ routers.r4.lo_ip4[0] }}
+    !
+    #%   endif
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }} 
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+  #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+     timers 3 10
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers connect 5
+     address-family ipv4 unicast
+      neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} disable-addpath-rx
+     exit-address-family
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+     timers 3 10
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers connect 5
+     neighbor {{ routers.r3.iface_to('s2').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r3.iface_to('s2').ip4[0].ip }} timers connect 5
+     neighbor {{ routers.r4.iface_to('s2').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r4.iface_to('s2').ip4[0].ip }} timers connect 5
+     address-family ipv4 unicast
+      neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} addpath-tx-all-paths
+     exit-address-family
+    !
+    #%   elif router.name == 'r3'
+    router bgp 65003
+     timers 3 10
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} timers connect 5
+     address-family ipv4 unicast
+      redistribute connected
+     exit-address-family
+    !
+    #%   elif router.name == 'r4'
+    router bgp 65004
+     timers 3 10
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r2.iface_to('s2').ip4[0].ip }} timers connect 5
+     address-family ipv4 unicast
+      redistribute connected
+     exit-address-family
+    !
+    #%   endif
+  #% endblock
+  """
+
+
+class BGPDisableAddpathRx(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def check_bgp_advertised_routes(self, _, r1, r2):
+        expected = {
+            "advertisedRoutes": {
+                "172.16.16.254/32": {
+                    "addrPrefix": "172.16.16.254",
+                    "prefixLen": 32,
+                },
+                "192.168.2.0/24": {
+                    "addrPrefix": "192.168.2.0",
+                    "prefixLen": 24,
+                },
+            },
+            "totalPrefixCounter": 2,
+        }
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show bgp ipv4 unicast neighbor {r1.iface_to('s1').ip4[0].ip} advertised-routes json",
+            maxwait=2.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def check_bgp_disabled_addpath_rx(self, _, r1, r2):
+        expected = {
+            str(r2.iface_to("s1").ip4[0].ip): {
+                "bgpState": "Established",
+                "neighborCapabilities": {
+                    "addPath": {
+                        "ipv4Unicast": {"txReceived": True, "rxReceived": True}
+                    },
+                },
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp neighbor {r2.iface_to('s1').ip4[0].ip} json",
+            maxwait=2.0,
+            compare=expected,
+        )


### PR DESCRIPTION
Signed-off-by: Nathan Mangar <nathan@thundergear.io>
Co-authored-by: Bruno Bernard <contact.brunobernard@gmail.com>

**Test Output** 

```
➜  basetato4 git:(bgp-disable-addpath-rx) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_disable_addpath_rx.py
===================================== topotato initialization ======================================

-------------------------------------- live log sessionstart ---------------------------------------
DEBUG    topotato:topolinux.py:88 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:88 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:88 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:88 executable ip found: /usr/sbin/ip
DEBUG    topotato:frr.py:143 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:158 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:197 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:209 zebra => zebra/zebra
DEBUG    topotato:frr.py:207 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:207 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:209 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:209 ripd => ripd/ripd
DEBUG    topotato:frr.py:209 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:209 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:209 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:209 isisd => isisd/isisd
DEBUG    topotato:frr.py:209 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:209 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:209 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:209 babeld => babeld/babeld
DEBUG    topotato:frr.py:209 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:209 pimd => pimd/pimd
DEBUG    topotato:frr.py:209 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:209 staticd => staticd/staticd
DEBUG    topotato:frr.py:209 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:209 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:209 pathd => pathd/pathd
DEBUG    topotato:frr.py:207 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:207 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:207 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:207 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:207 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:207 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:207 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:207 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:pretty.py:351 executable dot found: /usr/bin/dot
Warning: daemon 'pim6d' not enabled in configure, skipping
======================================= test session starts ========================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... --------------------------------------- live log collection ----------------------------------------
DEBUG    topotato:base.py:276 _topotato_makeitem(<Module test_disable_addpath_rx.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:276 _topotato_makeitem(<Module test_disable_addpath_rx.py>, 'BGPDisableAddpathRx', <class 'test_disable_addpath_rx.BGPDisableAddpathRx'>)
DEBUG    topotato:base.py:276 _topotato_makeitem(<Instance ()>, 'check_bgp_advertised_routes', <topotato.base.TopotatoWrapped object at 0x7f25d73628b0>)
DEBUG    topotato:base.py:276 _topotato_makeitem(<Instance ()>, 'check_bgp_disabled_addpath_rx', <topotato.base.TopotatoWrapped object at 0x7f25d7362970>)
DEBUG    topotato:base.py:683 collect on: <TopotatoFunction check_bgp_advertised_routes> test: <AssertVtysh #130:r2/bgpd/vtysh[show bgp ipv4 unicast neighbor 192.168.1.1 advertised-routes json]>
DEBUG    topotato:base.py:683 collect on: <TopotatoFunction check_bgp_disabled_addpath_rx> test: <AssertVtysh #151:r1/bgpd/vtysh[show bgp neighbor 192.168.1.2 json]>
collected 4 items                                                                                  

test_disable_addpath_rx.py::BGPDisableAddpathRx::startup 
------------------------------------------ live log setup ------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:324 <topotato.frr.FRRNetworkInstance object at 0x7f25d7359f10> tempdir created: /tmp/tmpqh3nda1a
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f25d7359f10> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpqh3nda1a/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f25d7359f10> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmpqh3nda1a/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f25d7359f10> temp-subdir for <RouterNS: 'r3'> created: /tmp/tmpqh3nda1a/r3
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f25d7359f10> temp-subdir for <RouterNS: 'r2'> created: /tmp/tmpqh3nda1a/r2
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f25d7359f10> temp-subdir for <RouterNS: 'r4'> created: /tmp/tmpqh3nda1a/r4
PASSED (1.74)                                                                                [ 25%]
test_disable_addpath_rx.py::BGPDisableAddpathRx::check_bgp_advertised_routes:#130:r2/bgpd/vtysh[show bgp ipv4 unicast neighbor 192.168.1.1 advertised-routes json] PASSED (2.00) [ 50%]
test_disable_addpath_rx.py::BGPDisableAddpathRx::check_bgp_disabled_addpath_rx:#151:r1/bgpd/vtysh[show bgp neighbor 192.168.1.2 json] PASSED (0.00) [ 75%]
test_disable_addpath_rx.py::BGPDisableAddpathRx::shutdown Running as user "root" and group "root". This could be dangerous.
tshark: The file "/tmp/topotato7c7s0hqu.pcapng" appears to be damaged or corrupt.
(pcapng_read_systemd_journal_export_block: total block length 204 is too small (< 212))
PASSED (1.09)                                              [100%]

==================================================== 4 passed in 5.64s =====================================================

```