### PR TITLE
topotato: test_bgp_aspath_zero.py

### DIFF
--- a/test_bgp_aspath_zero.py
+++ b/test_bgp_aspath_zero.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar for NetDEF, Inc.
+
+"""
+Test if BGP UPDATE with AS-PATH attribute with value zero (0)
+is threated as withdrawal.
+"""
+
+__topotests_file__ = "bgp_aspath_zero/test_bgp_aspath_zero.py"
+__topotests_gitrev__ = "a53c08bc131c02f4a20931d7aa9f974194ab16e7"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods, unused-argument, attribute-defined-outside-init
+from topotato import *
+from topotato.exabgp import ExaBGP
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }---[ peer1 ]
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "peer1"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }} 
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+  #% block main
+    #%   if router.name == 'r1'
+    router bgp 65534
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.peer1.ifaces[0].ip4[0].ip }} remote-as 65001
+      neighbor {{ routers.peer1.ifaces[0].ip4[0].ip }} timers 3 10
+    !
+    #%   endif
+  #% endblock
+  """
+
+
+class BGPAggregatorZero(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def prepare(self, peer1):
+
+        configuration = """
+neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} {
+  router-id {{ routers.peer1.ifaces[0].ip4[0].ip }};
+  local-address {{ routers.peer1.ifaces[0].ip4[0].ip }};
+  local-as 65001;
+  peer-as 65534;
+
+  static {
+    route 192.168.100.101/32 {
+      next-hop {{ routers.peer1.ifaces[0].ip4[0].ip }};
+    }
+
+    route 192.168.100.102/32 {
+      as-path [65000 0 65001];
+      next-hop {{ routers.peer1.ifaces[0].ip4[0].ip }};
+    }
+  }
+}
+      """
+        self.peer1 = ExaBGP(peer1, configuration)
+        yield from self.peer1.start()
+
+    @topotatofunc
+    def bgp_converge(self, r1, peer1):
+
+        expected = {
+            f"{peer1.ifaces[0].ip4[0].ip}": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 1}},
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show ip bgp neighbor {peer1.ifaces[0].ip4[0].ip} json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_has_correct_routes_without_asn_0(self, r1):
+
+        expected = {"routes": {"192.168.100.101/32": [{"valid": True}]}}
+
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            "show ip bgp json",
+            maxwait=5.0,
+            compare=expected,
+        )


### PR DESCRIPTION
**Test Output** 

```
➜  basetato4 git:(bgp-aspath-zero) ✗    ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_aspath_zero.py
================================================= topotato initialization =================================================

-------------------------------------------------- live log sessionstart --------------------------------------------------
DEBUG    topotato:topolinux.py:88 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:88 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:88 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:88 executable ip found: /usr/sbin/ip
DEBUG    topotato:frr.py:145 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:160 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:199 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:211 zebra => zebra/zebra
DEBUG    topotato:frr.py:209 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:209 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:211 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:211 ripd => ripd/ripd
DEBUG    topotato:frr.py:211 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:211 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:211 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:211 isisd => isisd/isisd
DEBUG    topotato:frr.py:211 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:211 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:211 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:211 babeld => babeld/babeld
DEBUG    topotato:frr.py:211 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:211 pimd => pimd/pimd
DEBUG    topotato:frr.py:211 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:211 staticd => staticd/staticd
DEBUG    topotato:frr.py:211 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:211 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:211 pathd => pathd/pathd
DEBUG    topotato:frr.py:209 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:209 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:209 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:209 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:209 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:209 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:209 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:209 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:209 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:209 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:pretty.py:278 executable dot found: /usr/bin/dot
Warning: daemon 'pim6d' not enabled in configure, skipping
=================================================== test session starts ===================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... --------------------------------------------------- live log collection ---------------------------------------------------
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_aspath_zero.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_aspath_zero.py>, 'BGPAggregatorZero', <class 'test_bgp_aspath_zero.BGPAggregatorZero'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'prepare', <topotato.base.TopotatoWrapped object at 0x7f5010deff10>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f5010deffd0>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'bgp_has_correct_routes_without_asn_0', <topotato.base.TopotatoWrapped object at 0x7f5010dfc070>)
DEBUG    topotato:base.py:684 collect on: <TopotatoFunction prepare> test: <Start #79:peer1 ExaBGP (Start)>
DEBUG    topotato:base.py:684 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #90:r1/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json]>
DEBUG    topotato:base.py:684 collect on: <TopotatoFunction bgp_has_correct_routes_without_asn_0> test: <AssertVtysh #103:r1/bgpd/vtysh[show ip bgp json]>
collected 5 items                                                                                                         

test_bgp_aspath_zero.py::BGPAggregatorZero::startup 
----------------------------------------------------- live log setup ------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:324 <topotato.frr.FRRNetworkInstance object at 0x7f5010e01d60> tempdir created: /tmp/tmpk_01ys9y
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f5010e01d60> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpk_01ys9y/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f5010e01d60> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmpk_01ys9y/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f5010e01d60> temp-subdir for <RouterNS: 'peer1'> created: /tmp/tmpk_01ys9y/peer1
PASSED (2.25)                                                                                                       [ 20%]
test_bgp_aspath_zero.py::BGPAggregatorZero::prepare:#79:peer1 ExaBGP (Start) 
------------------------------------------------------ live log call ------------------------------------------------------
DEBUG    root:_exabgp.py:89 exabgp tempfiles generated at /tmp/exabgp-20230219-113229-qj5a8em3
PASSED (1.49)                                                                                                       [ 40%]
test_bgp_aspath_zero.py::BGPAggregatorZero::bgp_converge:#90:r1/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json] PASSED (1.00) [ 60%]
test_bgp_aspath_zero.py::BGPAggregatorZero::bgp_has_correct_routes_without_asn_0:#103:r1/bgpd/vtysh[show ip bgp json] PASSED (0.01) [ 80%]
test_bgp_aspath_zero.py::BGPAggregatorZero::shutdown Running as user "root" and group "root". This could be dangerous.
PASSED (1.44)                                                  [100%]

==================================================== 5 passed in 9.63s ====================================================

```