### PR TITLE
topotato: test_bgp_aggregator_zero.py

### DIFF
--- a/test_bgp_aggregator_zero.py
+++ b/test_bgp_aggregator_zero.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar for NetDEF, Inc.
+
+"""
+Test if BGP UPDATE with AGGREGATOR AS attribute with value zero (0)
+is continued to be processed, but AGGREGATOR attribute is discarded.
+"""
+
+__topotests_file__ = "bgp_aggregator_zero/test_bgp_aggregator_zero.py"
+__topotests_gitrev__ = "a53c08bc131c02f4a20931d7aa9f974194ab16e7"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods, unused-argument, attribute-defined-outside-init
+from topotato import *
+from topotato.exabgp import ExaBGP
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }---[ peer1 ]
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "peer1"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }} 
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+  #% block main
+    #%   if router.name == 'r1'
+    router bgp 65534
+      no bgp ebgp-requires-policy
+      neighbor {{ routers.peer1.ifaces[0].ip4[0].ip }} remote-as external
+      neighbor {{ routers.peer1.ifaces[0].ip4[0].ip }} timers 3 10
+    !
+    #%   endif
+  #% endblock
+  """
+
+
+class BGPAggregatorZero(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def prepare(self, peer1):
+
+        configuration = """
+neighbor {{ routers.r1.ifaces[0].ip4[0].ip }} {
+  router-id {{ routers.peer1.ifaces[0].ip4[0].ip }};
+  local-address {{ routers.peer1.ifaces[0].ip4[0].ip }};
+  local-as 65001;
+  peer-as 65534;
+
+  static {
+		route 192.168.100.101/32 aggregator ( 0:{{ routers.peer1.ifaces[0].ip4[0].ip }} ) next-hop {{ routers.peer1.ifaces[0].ip4[0].ip }};
+        route 192.168.100.102/32 aggregator ( 65001:{{ routers.peer1.ifaces[0].ip4[0].ip }} ) next-hop {{ routers.peer1.ifaces[0].ip4[0].ip }};
+  }
+}
+      """
+        self.peer1 = ExaBGP(peer1, configuration)
+        yield from self.peer1.start()
+
+    @topotatofunc
+    def bgp_converge(self, r1, peer1):
+
+        expected = {
+            f"{peer1.ifaces[0].ip4[0].ip}": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show ip bgp neighbor {peer1.ifaces[0].ip4[0].ip} json",
+            maxwait=15.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_has_correct_routes_without_asn_0(self, r1):
+
+        expected = {["paths"][0]}
+
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            "show ip bgp 192.168.100.101/32 json",
+            compare=expected,
+            maxwait=3.0,
+        )
+
+    @topotatofunc
+    def bgp_has_correct_aggregator_route_with_good_asn(self, r1, peer1):
+
+        expected = {
+            "paths": [
+                {"aggregatorAs": 65001, "aggregatorId": f"{peer1.ifaces[0].ip4[0].ip}"}
+            ]
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show ip bgp 192.168.100.102/32 json",
+            maxwait=3.0,
+            compare=expected,
+        )


### PR DESCRIPTION
Test results

```
➜  basetato4 git:(bgp_aggregator_zero) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_aggregator_zero.py
======================================================================================= topotato initialization =======================================================================================

---------------------------------------------------------------------------------------- live log sessionstart ----------------------------------------------------------------------------------------
DEBUG    topotato:pretty.py:146 executable dot found: /usr/bin/dot
DEBUG    topotato:frr.py:149 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:164 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:203 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:215 zebra => zebra/zebra
DEBUG    topotato:frr.py:213 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:213 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:215 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:215 ripd => ripd/ripd
DEBUG    topotato:frr.py:215 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:215 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:215 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:215 isisd => isisd/isisd
DEBUG    topotato:frr.py:215 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:215 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:215 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:215 babeld => babeld/babeld
DEBUG    topotato:frr.py:215 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:215 pimd => pimd/pimd
DEBUG    topotato:frr.py:215 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:215 staticd => staticd/staticd
DEBUG    topotato:frr.py:215 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:215 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:215 pathd => pathd/pathd
DEBUG    topotato:frr.py:213 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:213 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:213 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:213 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:213 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:213 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:213 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:213 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:213 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:213 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:91 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:91 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:91 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:91 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... ----------------------------------------------------------------------------------------- live log collection -----------------------------------------------------------------------------------------
DEBUG    topotato:base.py:275 _topotato_makeitem(<Module test_bgp_aggregator_zero.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:275 _topotato_makeitem(<Module test_bgp_aggregator_zero.py>, 'BGPAggregatorZero', <class 'test_bgp_aggregator_zero.BGPAggregatorZero'>)
DEBUG    topotato:base.py:275 _topotato_makeitem(<Instance ()>, 'prepare', <topotato.base.TopotatoWrapped object at 0x7f11b9b62ca0>)
DEBUG    topotato:base.py:275 _topotato_makeitem(<Instance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f11b9b62d60>)
DEBUG    topotato:base.py:275 _topotato_makeitem(<Instance ()>, 'bgp_has_correct_routes_without_asn_0', <topotato.base.TopotatoWrapped object at 0x7f11b9b62dc0>)
DEBUG    topotato:base.py:275 _topotato_makeitem(<Instance ()>, 'bgp_has_correct_aggregator_route_with_good_asn', <topotato.base.TopotatoWrapped object at 0x7f11b9b62e20>)
DEBUG    topotato:base.py:682 collect on: <TopotatoFunction prepare> test: <Start #73:peer1 ExaBGP (Start)>
DEBUG    topotato:base.py:682 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #84:r1/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json]>
DEBUG    topotato:base.py:682 collect on: <TopotatoFunction bgp_has_correct_routes_without_asn_0> test: <AssertVtysh #97:r1/bgpd/vtysh[show ip bgp 192.168.100.101/32 json]>
DEBUG    topotato:base.py:682 collect on: <TopotatoFunction bgp_has_correct_aggregator_route_with_good_asn> test: <AssertVtysh #113:r1/bgpd/vtysh[show ip bgp 192.168.100.102/32 json]>
collected 6 items                                                                                                                                                                                     

test_bgp_aggregator_zero.py::BGPAggregatorZero::startup 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:327 <topotato.frr.FRRNetworkInstance object at 0x7f11b9b79b80> tempdir created: /tmp/tmp3j_wm_d_
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f11b9b79b80> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmp3j_wm_d_/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f11b9b79b80> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmp3j_wm_d_/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f11b9b79b80> temp-subdir for <RouterNS: 'peer1'> created: /tmp/tmp3j_wm_d_/peer1
PASSED (2.94)                                                                                                                                                                                   [ 16%]
test_bgp_aggregator_zero.py::BGPAggregatorZero::prepare:#73:peer1 ExaBGP (Start) 
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
DEBUG    root:_exabgp.py:89 exabgp tempfiles generated at /tmp/exabgp-20230318-191010-h0gkgdtn
PASSED (2.51)                                                                                                                                                                                   [ 33%]
test_bgp_aggregator_zero.py::BGPAggregatorZero::bgp_converge:#84:r1/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json] PASSED (1.49)                                                                                  [ 50%]
test_bgp_aggregator_zero.py::BGPAggregatorZero::bgp_has_correct_routes_without_asn_0:#97:r1/bgpd/vtysh[show ip bgp 192.168.100.101/32 json] PASSED (0.01)                                                           [ 66%]
test_bgp_aggregator_zero.py::BGPAggregatorZero::bgp_has_correct_aggregator_route_with_good_asn:#113:r1/bgpd/vtysh[show ip bgp 192.168.100.102/32 json] PASSED (0.01)                                                [ 83%]
test_bgp_aggregator_zero.py::BGPAggregatorZero::shutdown Running as user "root" and group "root". This could be dangerous.
tshark: The file "/tmp/topotaton596d3j5.pcapng" appears to be damaged or corrupt.
(pcapng_read_systemd_journal_export_block: total block length 180 is too small (< 212))
PASSED (1.60)                                                                                                                                              [100%]

=================================================================================================== 6 passed in 12.53s ====================================================================================================

```