### PR TITLE
topotato: WIP test_rip_allow_ecmp.py

### DIFF
--- a/test_rip_allow_ecmp.py
+++ b/test_rip_allow_ecmp.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Nathan Mangar
+
+
+"""
+Test if RIP `allow-ecmp` command works correctly.
+"""
+
+__topotests_file__ = "rip_allow_ecmp/test_rip_allow_ecmp.py"
+__topotests_gitrev__ = "4953ca977f3a5de8109ee6353ad07f816ca1774c"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }--[ r3 ]
+      |
+    [ r2 ]
+    """
+
+    topo.router("r2").lo_ip4.append("10.10.10.1/32")
+    topo.router("r3").lo_ip4.append("10.10.10.1/32")
+    topo.router("r1").iface_to("s1").ip4.append("192.168.1.1/24")
+    topo.router("r2").iface_to("s1").ip4.append("192.168.1.2/24")
+    topo.router("r3").iface_to("s1").ip4.append("192.168.1.3/24")
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2", "r3"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }}
+    !
+    #%   endfor
+    #% endblock
+    """
+
+    ripd_rtrs = ["r1", "r2", "r3"]
+    ripd = """
+    #% extends "boilerplate.conf"
+    #% block main
+    router rip
+    ##
+    #%   if router.name == 'r1'
+     allow-ecmp
+     network 192.168.1.0/24
+     timers basic 5 15 10
+    ##
+    #%   elif router.name == 'r2'
+     network 192.168.1.0/24
+     network 10.10.10.1/32
+     timers basic 5 15 10
+    ##
+    #%   elif router.name == 'r3'
+     network 192.168.1.0/24
+     network 10.10.10.1/32
+     timers basic 5 15 10
+    #%   endif
+    #% endblock
+    """
+
+
+class RIPAllowECMP(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def show_rip_routes(self, _, r1, r2):
+        expected = {
+            "route": [
+                {
+                    "prefix": "10.10.10.1/32",
+                    "nexthops": {
+                        "nexthop": [
+                            {
+                                "nh-type": "ip4",
+                                "protocol": "rip",
+                                "rip-type": "normal",
+                                "gateway": "192.168.1.2",
+                                "from": "192.168.1.2",
+                                "tag": 0,
+                            },
+                            {
+                                "nh-type": "ip4",
+                                "protocol": "rip",
+                                "rip-type": "normal",
+                                "gateway": "192.168.1.3",
+                                "from": "192.168.1.3",
+                                "tag": 0,
+                            },
+                        ]
+                    },
+                    "metric": 2,
+                },
+            ]
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "zebra",
+            f"show ip route json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def show_routes(self, _, r1, r2):
+        expected = {
+            "10.10.10.1/32": [
+                {
+                    "nexthops": [
+                        {
+                            "ip": "192.168.1.2",
+                            "active": True,
+                        },
+                        {
+                            "ip": "192.168.1.3",
+                            "active": True,
+                        },
+                    ]
+                }
+            ]
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "zebra",
+            f"show ip route json",
+            maxwait=5.0,
+            compare=expected,
+        )


### PR DESCRIPTION
**( Work In Progress )**
The show_routes function works but the show_rip_routes doesn't. This could be due to some improper config or an issue within topotato. The IPs are set to the default ones used in the original topotest but will be replaced by the auto ones later on.

Here's the test result:

```
➜  basetato4 git:(rip-allow-ecmp) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_rip_allow_ecmp.py
================================================================================================================================================================================================================== topotato initialization ==================================================================================================================================================================================================================

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- live log sessionstart -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEBUG    topotato:pretty.py:146 executable dot found: /usr/bin/dot
DEBUG    topotato:frr.py:140 FRR build directory: '/root/buildfrr'
DEBUG    topotato:frr.py:155 FRR source directory: '/root/buildfrr'
INFO     topotato:frr.py:194 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:frr.py:206 zebra => zebra/zebra
DEBUG    topotato:frr.py:204 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:frr.py:204 ignoring target 'tools/ssd'
DEBUG    topotato:frr.py:206 bgpd => bgpd/bgpd
DEBUG    topotato:frr.py:206 ripd => ripd/ripd
DEBUG    topotato:frr.py:206 ripngd => ripngd/ripngd
DEBUG    topotato:frr.py:206 ospfd => ospfd/ospfd
DEBUG    topotato:frr.py:206 ospf6d => ospf6d/ospf6d
DEBUG    topotato:frr.py:206 isisd => isisd/isisd
DEBUG    topotato:frr.py:206 fabricd => isisd/fabricd
DEBUG    topotato:frr.py:206 nhrpd => nhrpd/nhrpd
DEBUG    topotato:frr.py:206 ldpd => ldpd/ldpd
DEBUG    topotato:frr.py:206 babeld => babeld/babeld
DEBUG    topotato:frr.py:206 eigrpd => eigrpd/eigrpd
DEBUG    topotato:frr.py:206 pimd => pimd/pimd
DEBUG    topotato:frr.py:206 pbrd => pbrd/pbrd
DEBUG    topotato:frr.py:206 staticd => staticd/staticd
DEBUG    topotato:frr.py:206 bfdd => bfdd/bfdd
DEBUG    topotato:frr.py:206 vrrpd => vrrpd/vrrpd
DEBUG    topotato:frr.py:206 pathd => pathd/pathd
DEBUG    topotato:frr.py:204 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:frr.py:204 ignoring target 'lib/clippy'
DEBUG    topotato:frr.py:204 ignoring target 'tools/permutations'
DEBUG    topotato:frr.py:204 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:frr.py:204 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:frr.py:204 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:frr.py:204 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:frr.py:204 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:frr.py:204 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:frr.py:204 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:91 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:91 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:91 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:91 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
==================================================================================================================================================================================================================== test session starts ====================================================================================================================================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- live log collection --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_rip_allow_ecmp.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_rip_allow_ecmp.py>, 'RIPAllowECMP', <class 'test_rip_allow_ecmp.RIPAllowECMP'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'show_rip_routes', <topotato.base.TopotatoWrapped object at 0x7f94aadf7e50>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'show_routes', <topotato.base.TopotatoWrapped object at 0x7f94aadf7f10>)
DEBUG    topotato:base.py:689 collect on: <TopotatoFunction show_rip_routes> test: <AssertVtysh #106:r1/ripd/vtysh[show ip ripd status json]>
DEBUG    topotato:base.py:689 collect on: <TopotatoFunction show_routes> test: <AssertVtysh #132:r1/zebra/vtysh[show ip route json]>
collected 4 items                                                                                                                                                                                                                                                                                                                                                                                                                                           

test_rip_allow_ecmp.py::RIPAllowECMP::startup 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:327 <topotato.frr.FRRNetworkInstance object at 0x7f94aae0f1f0> tempdir created: /tmp/tmp6h4bbqqu
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f94aae0f1f0> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmp6h4bbqqu/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f94aae0f1f0> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmp6h4bbqqu/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f94aae0f1f0> temp-subdir for <RouterNS: 'r3'> created: /tmp/tmp6h4bbqqu/r3
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.FRRNetworkInstance object at 0x7f94aae0f1f0> temp-subdir for <RouterNS: 'r2'> created: /tmp/tmp6h4bbqqu/r2
PASSED (2.86)                                                                                                                                                                                                                                                                                                                                                                                                                                         [ 25%]
test_rip_allow_ecmp.py::RIPAllowECMP::show_rip_routes:#106:r1/ripd/vtysh[show ip ripd status json] FAILED                                                                                                                                                                                                                                                                                                                                             [ 50%]

========================================================================================================================================================================================================================= FAILURES ==========================================================================================================================================================================================================================
_______________________________________________________________________________________________________________________________________________________________________________________________________ #106:r1/ripd/vtysh[show ip ripd status json] ________________________________________________________________________________________________________________________________________________________________________________________________________

self = <test_rip_allow_ecmp.RIPAllowECMP object at 0x7f94abc71fd0>, _ = None, r1 = <Router 1 "r1">, r2 = <Router 2 "r2">

    @topotatofunc
    def show_rip_routes(self, _, r1, r2):
        expected = {
            "route": [
                {
                    "prefix": "10.10.10.1/32",
                    "nexthops": {
                        "nexthop": [
                            {
                                "nh-type": "ip4",
                                "protocol": "rip",
                                "rip-type": "normal",
                                "gateway": "192.168.1.2",
                                "from": "192.168.1.2",
                                "tag": 0,
                            },
                            {
                                "nh-type": "ip4",
                                "protocol": "rip",
                                "rip-type": "normal",
                                "gateway": "192.168.1.3",
                                "from": "192.168.1.3",
                                "tag": 0,
                            },
                        ]
                    },
                    "metric": 2,
                },
            ]
        }
>       yield from AssertVtysh.make(
            r1,
            "ripd",
            f"show ip ripd status json",
            maxwait=5.0,
            compare=expected,
        )
E       topotato.exceptions.TopotatoCLIUnsuccessfulFail: vtysh return value 2, output: % [RIP] Unknown command: show ip ripd status json

/root/basetato4/test_rip_allow_ecmp.py:106: TopotatoCLIUnsuccessfulFail
================================================================================================================================================================================================================== short test summary info ==================================================================================================================================================================================================================
FAILED test_rip_allow_ecmp.py::RIPAllowECMP::show_rip_routes:#106:r1/ripd/vtysh[show ip ripd status json] - topotato.exceptions.TopotatoCLIUnsuccessfulFail: vtysh return value 2, output: % [RIP] Unknown command: show ip ripd status json
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================================================================================================================================ 1 failed, 1 passed in 8.21s ================================================================================================================================================================================================================
```