### PR TITLE
topotato: test_bgp_unnumbered.py

### DIFF
--- a/test_bgp_unnumbered.py
+++ b/test_bgp_unnumbered.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar
+
+"""
+Test some bgp interface based issues that show up
+"""
+
+__topotests_file__ = "bgp_unnumbered/test_bgp_unnumbered.py"
+__topotests_gitrev__ = "acddc0ed3ce0833490b7ef38ed000d54388ebea4"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }
+      |
+    [ r2 ]
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }}
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+    #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+     timers bgp 1 9
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} interface remote-as external
+     address-family ipv4 unicast
+     exit-address-family
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+     no bgp network import-check
+     no bgp ebgp-requires-policy
+     timers bgp 1 9
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} interface remote-as external
+     address-family ipv4 uni
+        network 172.16.255.254/32
+    !
+    #%   endif
+    #% endblock
+  """
+
+
+class BGPUnnumberedRemoval(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def bgp_converge(self, _, r1):
+        expected = {"prefix": "172.16.255.254/32"}
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show ip bgp 172.16.255.254/32 json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def shutdown_interface_r1_eth0(self, _, r1):
+        yield from AssertVtysh.make(
+            r1,
+            "zebra",
+            """
+            enable
+            configure
+            int r1-eth0
+             shutdown
+            """,
+            compare="",
+        )
+
+    @topotatofunc
+    def remove_neighbor_from_r1(self, _, r1):
+        yield from AssertVtysh.make(
+            r1,
+            "zebra",
+            """
+            enable
+            configure
+            router bgp
+             no neighbor r1-eth0 interface remote-as external
+            """,
+            compare="",
+        )
+
+    @topotatofunc
+    def bgp_nexthop_cache(self, _, r1):
+        expected = "Current BGP nexthop cache:\n"
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp nexthop",
+            maxwait=5.0,
+            compare=expected,
+        )

--- a/topotato/generatorwrap.py
+++ b/topotato/generatorwrap.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Optional,
     TypeVar,
+    Type,
 )
 
 
@@ -104,7 +105,7 @@ class GeneratorChecks:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         tb: Optional[TracebackType],
     ):


### PR DESCRIPTION
**( Work In Progress )**
Only shutdown_interface_r1_eth0 works for the moment. One possible culprit is the bgpd config for r2. The whole test uses auto IPs except for 172.16.255.254/32 in r2.

Here's the test result:

```
➜  basetato4 git:(bgp-unnumbered) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_unnumbered.py
============================================================================== topotato initialization ==============================================================================

------------------------------------------------------------------------------- live log sessionstart -------------------------------------------------------------------------------
DEBUG    topotato:pretty.py:146 executable dot found: /usr/bin/dot
DEBUG    topotato:core.py:140 FRR build directory: '/root/buildfrr'
DEBUG    topotato:core.py:155 FRR source directory: '/root/buildfrr'
INFO     topotato:core.py:194 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:core.py:206 zebra => zebra/zebra
DEBUG    topotato:core.py:204 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:core.py:204 ignoring target 'tools/ssd'
DEBUG    topotato:core.py:206 bgpd => bgpd/bgpd
DEBUG    topotato:core.py:206 ripd => ripd/ripd
DEBUG    topotato:core.py:206 ripngd => ripngd/ripngd
DEBUG    topotato:core.py:206 ospfd => ospfd/ospfd
DEBUG    topotato:core.py:206 ospf6d => ospf6d/ospf6d
DEBUG    topotato:core.py:206 isisd => isisd/isisd
DEBUG    topotato:core.py:206 fabricd => isisd/fabricd
DEBUG    topotato:core.py:206 nhrpd => nhrpd/nhrpd
DEBUG    topotato:core.py:206 ldpd => ldpd/ldpd
DEBUG    topotato:core.py:206 babeld => babeld/babeld
DEBUG    topotato:core.py:206 eigrpd => eigrpd/eigrpd
DEBUG    topotato:core.py:206 pimd => pimd/pimd
DEBUG    topotato:core.py:206 pbrd => pbrd/pbrd
DEBUG    topotato:core.py:206 staticd => staticd/staticd
DEBUG    topotato:core.py:206 bfdd => bfdd/bfdd
DEBUG    topotato:core.py:206 vrrpd => vrrpd/vrrpd
DEBUG    topotato:core.py:206 pathd => pathd/pathd
DEBUG    topotato:core.py:204 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:core.py:204 ignoring target 'lib/clippy'
DEBUG    topotato:core.py:204 ignoring target 'tools/permutations'
DEBUG    topotato:core.py:204 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:core.py:204 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:core.py:204 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:core.py:204 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:core.py:204 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:core.py:204 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:core.py:204 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:91 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:91 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:91 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:91 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
================================================================================ test session starts ================================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.11.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4, configfile: pytest.ini
collecting ... -------------------------------------------------------------------------------- live log collection --------------------------------------------------------------------------------
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_unnumbered.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_unnumbered.py>, 'BGPUnnumberedRemoval', <class 'test_bgp_unnumbered.BGPUnnumberedRemoval'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7ff6a5b332b0>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'shutdown_interface_r1_eth0', <topotato.base.TopotatoWrapped object at 0x7ff6a5b33280>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'remove_neighbor_from_r1', <topotato.base.TopotatoWrapped object at 0x7ff6a5b33130>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Instance ()>, 'bgp_nexthop_cache', <topotato.base.TopotatoWrapped object at 0x7ff6a5b33190>)
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #72:r1/bgpd/vtysh[show ip bgp 172.16.255.254/32 json]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction shutdown_interface_r1_eth0> test: <AssertVtysh #82:r1/zebra/vtysh[;             enable;             configure;             interface r1-eth0;              shutdown;             ]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction remove_neighbor_from_r1> test: <AssertVtysh #96:r1/zebra/vtysh[;             enable;             configure;             router bgp;              no neighbor r1-eth0 interface remote-as external;             ]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_nexthop_cache> test: <AssertVtysh #111:r1/bgpd/vtysh[show bgp nexthop]>
collected 6 items                                                                                                                                                                   

test_bgp_unnumbered.py::BGPUnnumberedRemoval::startup 
---------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:327 <topotato.frr.core.FRRNetworkInstance object at 0x7ff6a6882190> tempdir created: /tmp/tmpitvx7bgv
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.core.FRRNetworkInstance object at 0x7ff6a6882190> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpitvx7bgv/switch-ns
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.core.FRRNetworkInstance object at 0x7ff6a6882190> temp-subdir for <RouterNS: 'r1'> created: /tmp/tmpitvx7bgv/r1
DEBUG    topotato.topolinux:topolinux.py:113 <topotato.frr.core.FRRNetworkInstance object at 0x7ff6a6882190> temp-subdir for <RouterNS: 'r2'> created: /tmp/tmpitvx7bgv/r2
PASSED (2.18)                                                                                                                                                                 [ 16%]
test_bgp_unnumbered.py::BGPUnnumberedRemoval::bgp_converge:#72:r1/bgpd/vtysh[show ip bgp 172.16.255.254/32 json] FAILED                                                       [ 33%]

===================================================================================== FAILURES ======================================================================================
_______________________________________________________________ #72:r1/bgpd/vtysh[show ip bgp 172.16.255.254/32 json] _______________________________________________________________

self = <test_bgp_unnumbered.BGPUnnumberedRemoval object at 0x7ff6a5b339a0>, _ = None, r1 = <Router 1 "r1">

    @topotatofunc
    def bgp_converge(self, _, r1):
        expected = {"prefix": "172.16.255.254/32"}
>       yield from AssertVtysh.make(
            r1,
            "bgpd",
            f"show ip bgp 172.16.255.254/32 json",
            maxwait=5.0,
            compare=expected,
        )
E       topotato.exceptions.TopotatoCLICompareFail: expected key(s) ['prefix'] in json (have []):
E       --- Expected value
E       +++ Current value
E       @@ -1,3 +1 @@
E       -{
E       -    "prefix": "172.16.255.254/32"
E       -}
E       +{}

/root/basetato4/test_bgp_unnumbered.py:72: TopotatoCLICompareFail
============================================================================== short test summary info ==============================================================================
FAILED test_bgp_unnumbered.py::BGPUnnumberedRemoval::bgp_converge:#72:r1/bgpd/vtysh[show ip bgp 172.16.255.254/32 json] - topotato.exceptions.TopotatoCLICompareFail: expected key...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================ 1 failed, 1 passed in 7.76s ============================================================================
```