### PR TITLE
topotato: test_bgp_max_med_on_startup.py

### DIFF
--- a/test_bgp_max_med_on_startup.py
+++ b/test_bgp_max_med_on_startup.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar
+
+"""
+Test whether `bgp max-med on-startup (5-86400) [(0-4294967295)]` is working
+correctly.
+"""
+
+__topotests_file__ = "bgp_max_med_on_startup/test_bgp_max_med_on_startup.py"
+__topotests_gitrev__ = "acddc0ed3ce0833490b7ef38ed000d54388ebea4"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods, unused-argument
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }
+      |
+    [ r2 ]
+
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }}
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+    #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+     bgp max-med on-startup 5 777
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} remote-as 65002
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers 3 10
+     address-family ipv4 unicast
+      redistribute connected
+     exit-address-family
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} remote-as 65001
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers 3 10
+    !
+    #%   endif
+    #% endblock
+  """
+
+
+class BGPMaxMedOnStartup(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def bgp_converge(self, _, r1, r2):
+        expected = {str(r1.iface_to("s1").ip4[0].ip): {"bgpState": "Established"}}
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show ip bgp neighbor {r1.iface_to('s1').ip4[0].ip} json",
+            maxwait=2.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_has_routes(self, _, r1, r2):
+        expected = {"routes": {str(r1.lo_ip4[0]): [{"metric": 777}]}}
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show ip bgp neighbor {r1.iface_to('s1').ip4[0].ip} routes json",
+            maxwait=2.0,
+            compare=expected,
+        )

--- a/topotato/generatorwrap.py
+++ b/topotato/generatorwrap.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Optional,
     TypeVar,
+    Type,
 )
 
 
@@ -104,7 +105,7 @@ class GeneratorChecks:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         tb: Optional[TracebackType],
     ):


### PR DESCRIPTION
Test output:

```
➜  basetato4 git:(bgp-max-med-on-startup) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_max_med_on_startup.py
==================================================================================== topotato initialization ====================================================================================

------------------------------------------------------------------------------------- live log sessionstart -------------------------------------------------------------------------------------
DEBUG    topotato:pretty.py:145 executable dot found: /usr/bin/dot
DEBUG    topotato:core.py:160 FRR build directory: '/root/buildfrr/'
DEBUG    topotato:core.py:182 FRR source directory: '/root/buildfrr'
INFO     topotato:core.py:226 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:core.py:238 zebra => zebra/zebra
DEBUG    topotato:core.py:236 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:core.py:236 ignoring target 'tools/ssd'
DEBUG    topotato:core.py:238 bgpd => bgpd/bgpd
DEBUG    topotato:core.py:238 ripd => ripd/ripd
DEBUG    topotato:core.py:238 ripngd => ripngd/ripngd
DEBUG    topotato:core.py:238 ospfd => ospfd/ospfd
DEBUG    topotato:core.py:238 ospf6d => ospf6d/ospf6d
DEBUG    topotato:core.py:238 isisd => isisd/isisd
DEBUG    topotato:core.py:238 fabricd => isisd/fabricd
DEBUG    topotato:core.py:238 nhrpd => nhrpd/nhrpd
DEBUG    topotato:core.py:238 ldpd => ldpd/ldpd
DEBUG    topotato:core.py:238 babeld => babeld/babeld
DEBUG    topotato:core.py:238 eigrpd => eigrpd/eigrpd
DEBUG    topotato:core.py:238 pimd => pimd/pimd
DEBUG    topotato:core.py:238 pbrd => pbrd/pbrd
DEBUG    topotato:core.py:238 staticd => staticd/staticd
DEBUG    topotato:core.py:238 bfdd => bfdd/bfdd
DEBUG    topotato:core.py:238 vrrpd => vrrpd/vrrpd
DEBUG    topotato:core.py:238 pathd => pathd/pathd
DEBUG    topotato:core.py:236 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:core.py:236 ignoring target 'lib/clippy'
DEBUG    topotato:core.py:236 ignoring target 'tools/permutations'
DEBUG    topotato:core.py:236 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:core.py:236 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:core.py:236 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:core.py:236 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:core.py:236 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:core.py:236 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:core.py:236 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:92 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:92 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:92 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:92 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4
configfile: pytest.ini
collecting ... -------------------------------------------------------------------------------------- live log collection --------------------------------------------------------------------------------------
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_max_med_on_startup.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_max_med_on_startup.py>, 'BGPMaxMedOnStartup', <class 'test_bgp_max_med_on_startup.BGPMaxMedOnStartup'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPMaxMedOnStartup>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f13e1fcc3d0>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPMaxMedOnStartup>, 'bgp_has_routes', <topotato.base.TopotatoWrapped object at 0x7f13e1c9fb90>)
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #72:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_has_routes> test: <AssertVtysh #83:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 routes json]>
collected 4 items                                                                                                                                                                               

test_bgp_max_med_on_startup.py::BGPMaxMedOnStartup::startup 
---------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:326 <topotato.network.TopotatoNetwork object at 0x7f13e1dd9790> tempdir created: /tmp/tmpa57vtyhe
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f13e1dd9790> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpa57vtyhe/switch-ns
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f13e1dd9790> temp-subdir for <FRRRouterNS: 'r1'> created: /tmp/tmpa57vtyhe/r1
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f13e1dd9790> temp-subdir for <FRRRouterNS: 'r2'> created: /tmp/tmpa57vtyhe/r2
PASSED (3.37)                                                                                                                                                                             [ 25%]
test_bgp_max_med_on_startup.py::BGPMaxMedOnStartup::bgp_converge:#72:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json] PASSED (0.74)                                                    [ 50%]
test_bgp_max_med_on_startup.py::BGPMaxMedOnStartup::bgp_has_routes:#83:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 routes json] PASSED (1.10)                                           [ 75%]
test_bgp_max_med_on_startup.py::BGPMaxMedOnStartup::shutdown Running as user "root" and group "root". This could be dangerous.
tshark: The file "/tmp/topotatofcbv0hkx.pcapng" appears to be damaged or corrupt.
(pcapng_read_systemd_journal_export_block: total block length 204 is too small (< 212))
PASSED (1.38)                                                                                                                [100%]

======================================================================================= warnings summary ========================================================================================
../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)

../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ 4 passed, 2 warnings in 11.02s =================================================================================
```