### PR TITLE
topotato: test_bgp_gr_restart_retain_routes.py

### DIFF
--- a/test_bgp_gr_restart_retain_routes.py
+++ b/test_bgp_gr_restart_retain_routes.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar
+
+"""
+Test if routes are retained during BGP restarts.
+"""
+
+__topotests_file__ = "bgp_gr_restart_retain_routes/test_bgp_gr_restart_retain_routes.py"
+__topotests_gitrev__ = "6a62adabb3938b1f478d04500e2d918b43f6107d"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods, unused-argument
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }
+      |
+    [ r2 ]
+
+    """
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }}
+    !
+    #%   endfor
+    #% endblock
+    """
+
+    bgpd = """
+    #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+     no bgp ebgp-requires-policy
+     bgp graceful-restart
+     bgp graceful-restart preserve-fw-state
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers 1 3
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers connect 1
+     address-family ipv4
+      redistribute connected
+     exit-address-family
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+     no bgp ebgp-requires-policy
+     bgp graceful-restart
+     bgp graceful-restart preserve-fw-state
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} remote-as external
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers 1 3
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers connect 1
+    !
+    #%   endif
+    #% endblock
+    """
+
+
+class BGPGrRestartRetainRoutes(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def bgp_converge(self, r1, r2):
+        expected = {
+            str(r1.iface_to("s1").ip4[0].ip): {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show bgp ipv4 neighbors {r1.iface_to('s1').ip4[0].ip} json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_check_bgp_retained_routes(self, r1, r2):
+        expected = {"paths": [{"stale": True}]}
+        yield from AssertVtysh.make(
+            r2,
+            "vtysh",
+            f"clear ip bgp * soft",
+            maxwait=5.0,
+            compare="",
+        )
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show bgp ipv4 unicast {r1.lo_ip4[0]} json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_check_kernel_retained_routes(self, r1, r2):
+        expected = [
+            {
+                "dst": str(r1.lo_ip4[0]),
+                "gateway": str(r1.iface_to("s1").ip4[0].ip),
+                "metric": 20,
+            }
+        ]
+        yield from AssertVtysh.make(
+            r2,
+            "vtysh",
+            f"show ip bgp neighbor {r1.lo_ip4[0]} advertised-routes json",
+            maxwait=5.0,
+            compare=expected,
+        )

--- a/topotato/generatorwrap.py
+++ b/topotato/generatorwrap.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Optional,
     TypeVar,
+    Type,
 )
 
 
@@ -104,7 +105,7 @@ class GeneratorChecks:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         tb: Optional[TracebackType],
     ):


### PR DESCRIPTION
**Test result:**

```
➜  basetato4 git:(bgp-gr-restart-retain-routes) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_gr_restart_retain_routes.py
=================================================================== topotato initialization ====================================================================

-------------------------------------------------------------------- live log sessionstart ---------------------------------------------------------------------
DEBUG    topotato:pretty.py:145 executable dot found: /usr/bin/dot
DEBUG    topotato:core.py:160 FRR build directory: '/root/buildfrr/'
DEBUG    topotato:core.py:182 FRR source directory: '/root/buildfrr'
INFO     topotato:core.py:226 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:core.py:238 zebra => zebra/zebra
DEBUG    topotato:core.py:236 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:core.py:236 ignoring target 'tools/ssd'
DEBUG    topotato:core.py:238 bgpd => bgpd/bgpd
DEBUG    topotato:core.py:238 ripd => ripd/ripd
DEBUG    topotato:core.py:238 ripngd => ripngd/ripngd
DEBUG    topotato:core.py:238 ospfd => ospfd/ospfd
DEBUG    topotato:core.py:238 ospf6d => ospf6d/ospf6d
DEBUG    topotato:core.py:238 isisd => isisd/isisd
DEBUG    topotato:core.py:238 fabricd => isisd/fabricd
DEBUG    topotato:core.py:238 nhrpd => nhrpd/nhrpd
DEBUG    topotato:core.py:238 ldpd => ldpd/ldpd
DEBUG    topotato:core.py:238 babeld => babeld/babeld
DEBUG    topotato:core.py:238 eigrpd => eigrpd/eigrpd
DEBUG    topotato:core.py:238 pimd => pimd/pimd
DEBUG    topotato:core.py:238 pbrd => pbrd/pbrd
DEBUG    topotato:core.py:238 staticd => staticd/staticd
DEBUG    topotato:core.py:238 bfdd => bfdd/bfdd
DEBUG    topotato:core.py:238 vrrpd => vrrpd/vrrpd
DEBUG    topotato:core.py:238 pathd => pathd/pathd
DEBUG    topotato:core.py:236 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:core.py:236 ignoring target 'lib/clippy'
DEBUG    topotato:core.py:236 ignoring target 'tools/permutations'
DEBUG    topotato:core.py:236 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:core.py:236 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:core.py:236 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:core.py:236 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:core.py:236 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:core.py:236 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:core.py:236 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:92 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:92 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:92 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:92 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
===================================================================== test session starts ======================================================================
platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4
configfile: pytest.ini
collecting ... --------------------------------------------------------------------- live log collection ----------------------------------------------------------------------
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_gr_restart_retain_routes.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_gr_restart_retain_routes.py>, 'BGPGrRestartRetainRoutes', <class 'test_bgp_gr_restart_retain_routes.BGPGrRestartRetainRoutes'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPGrRestartRetainRoutes>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f1dcb0fe750>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPGrRestartRetainRoutes>, 'bgp_check_bgp_retained_routes', <topotato.base.TopotatoWrapped object at 0x7f1dcaddadd0>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPGrRestartRetainRoutes>, 'bgp_check_kernel_retained_routes', <topotato.base.TopotatoWrapped object at 0x7f1dc90bce90>)
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #79:r2/bgpd/vtysh[show bgp ipv4 neighbors 10.101.0.1 json]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_check_bgp_retained_routes> test: <AssertVtysh #90:r2/vtysh/vtysh[clear ip bgp * soft]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_check_bgp_retained_routes> test: <AssertVtysh #97:r2/bgpd/vtysh[show bgp ipv4 unicast 10.255.0.1/32 json]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_check_kernel_retained_routes> test: <AssertVtysh #114:r2/vtysh/vtysh[show ip bgp neighbor 10.255.0.1/32 advertised-routes json]>
collected 6 items                                                                                                                                              

test_bgp_gr_restart_retain_routes.py::BGPGrRestartRetainRoutes::startup 
------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:326 <topotato.network.TopotatoNetwork object at 0x7f1dcadc6350> tempdir created: /tmp/tmpv8ja5yio
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f1dcadc6350> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpv8ja5yio/switch-ns
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f1dcadc6350> temp-subdir for <FRRRouterNS: 'r1'> created: /tmp/tmpv8ja5yio/r1
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f1dcadc6350> temp-subdir for <FRRRouterNS: 'r2'> created: /tmp/tmpv8ja5yio/r2
PASSED (1.33)                                                                                                                                            [ 16%]
test_bgp_gr_restart_retain_routes.py::BGPGrRestartRetainRoutes::bgp_converge:#79:r2/bgpd/vtysh[show bgp ipv4 neighbors 10.101.0.1 json] PASSED (1.50)    [ 33%]
test_bgp_gr_restart_retain_routes.py::BGPGrRestartRetainRoutes::bgp_check_bgp_retained_routes:#90:r2/vtysh/vtysh[clear ip bgp * soft] PASSED (0.12)      [ 50%]
test_bgp_gr_restart_retain_routes.py::BGPGrRestartRetainRoutes::bgp_check_bgp_retained_routes:#97:r2/bgpd/vtysh[show bgp ipv4 unicast 10.255.0.1/32 json] PASSED (0.00) [ 66%]
test_bgp_gr_restart_retain_routes.py::BGPGrRestartRetainRoutes::bgp_check_kernel_retained_routes:#114:r2/vtysh/vtysh[show ip bgp neighbor 10.255.0.1/32 advertised-routes json] PASSED (0.06) [ 83%]
test_bgp_gr_restart_retain_routes.py::BGPGrRestartRetainRoutes::shutdown Running as user "root" and group "root". This could be dangerous.
tshark: The file "/tmp/topotatofs_4f82w.pcapng" appears to be damaged or corrupt.
(pcapng_read_systemd_journal_export_block: total block length 180 is too small (< 212))
PASSED (1.29)                                                                   [100%]

======================================================================= warnings summary =======================================================================
../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)

../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 6 passed, 2 warnings in 6.25s =================================================================
```
