### PR TITLE
topotato: test_bgp_confederation_astype.py

### DIFF
--- a/test_bgp_confederation_astype.py
+++ b/test_bgp_confederation_astype.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar
+
+"""
+Test if BGP confederation works properly when using
+remote-as internal/external.
+
+Also, check if the same works with peer-groups as well.
+"""
+
+__topotests_file__ = "bgp_confederation_astype/test_bgp_confederation_astype.py"
+__topotests_gitrev__ = "caf65e4a27539b1ecc0f6820994d36278c0e63e6"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r3 ]--{ s2 }
+              |
+    { s1 }--[ r1 ]
+      |
+    [ r2 ]
+
+    """
+
+    # topo.router("r1").lo_ip4.append("172.16.255.254/32")
+    # topo.router("r3").lo_ip4.append("172.16.255.32/32")
+
+    topo.router("r2").lo_ip4.append("172.16.255.254/32")
+    # topo.router("r3").lo_ip4.append("172.16.255.254/32")
+
+    topo.router("r1").iface_to("s1").ip4.append("192.168.1.1/24")
+    topo.router("r1").iface_to("s2").ip4.append("192.168.2.1/24")
+
+    topo.router("r2").iface_to("s1").ip4.append("192.168.1.2/24")
+
+    topo.router("r3").iface_to("s2").ip4.append("192.168.2.2/24")
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2", "r3"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }}
+    !
+    #%   endfor
+    #% endblock
+    """
+
+    # There seems to be an issue with the R1 config. R1 is blocking any packets it receives for some reason.
+
+    bgpd = """
+    #% block main
+    #%   if router.name == 'r1'
+    router bgp 65001
+     no bgp ebgp-requires-policy
+     bgp confederation identifier 65300
+     bgp confederation peers 65002 65003
+     neighbor fabric peer-group
+     neighbor fabric remote-as external
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} peer-group fabric
+     neighbor {{ routers.r3.iface_to('s2').ip4[0].ip }} remote-as external
+     address-family ipv4 unicast
+      neighbor fabric soft-reconfiguration inbound
+      neighbor fabric activate
+      neighbor {{ routers.r3.iface_to('s2').ip4[0].ip }} soft-reconfiguration inbound
+     exit-address-family
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65002
+     no bgp ebgp-requires-policy
+     no bgp network import-check
+     bgp confederation identifier 65300
+     bgp confederation peers 65001
+     neighbor fabric peer-group
+     neighbor fabric remote-as external
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} peer-group fabric
+     address-family ipv4 unicast
+      network {{ routers.r2.lo_ip4[0] }}
+      neighbor fabric activate
+     exit-address-family
+    !
+    #%   elif router.name == 'r3'
+    router bgp 65003
+     no bgp ebgp-requires-policy
+     no bgp network import-check
+     bgp confederation identifier 65300
+     bgp confederation peers 65001 
+     neighbor {{ routers.r1.iface_to('s2').ip4[0].ip }} remote-as external
+     address-family ipv4 unicast
+      network {{ routers.r2.lo_ip4[0] }}
+     exit-address-family
+    !
+    #%   endif
+    #% endblock
+    """
+
+
+class BGPConfederationAstype(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def bgp_converge(self, _, r1, r2, r3):
+        expected = {
+            "ipv4Unicast": {
+                "peerCount": 2,
+                "peers": {
+                    str(r2.iface_to("s1").ip4[0].ip): {
+                        "hostname": "r2",
+                        "remoteAs": 65002,
+                        "localAs": 65001,
+                        "pfxRcd": 1,
+                        "state": "Established",
+                    },
+                    str(r3.iface_to("s2").ip4[0].ip): {
+                        "hostname": "r3",
+                        "remoteAs": 65003,
+                        "localAs": 65001,
+                        "pfxRcd": 1,
+                        "state": "Established",
+                    },
+                },
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp summary json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_check_neighbors(self, _, r1, r3, r2):
+        expected = {
+            str(r2.iface_to("s1").ip4[0].ip): {
+                "nbrCommonAdmin": True,
+                "nbrConfedExternalLink": True,
+                "hostname": "r2",
+            },
+            str(r3.iface_to("s2").ip4[0].ip): {
+                "nbrCommonAdmin": True,
+                "nbrConfedExternalLink": True,
+                "hostname": "r3",
+            },
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp neighbors json",
+            maxwait=5.0,
+            compare=expected,
+        )
+
+    @topotatofunc
+    def bgp_check_routes(self, _, r1, r2):
+        expected = {
+            "routes": {
+                str(r2.lo_ip4[0]): [
+                    {
+                        "valid": True,
+                        "pathFrom": "external",
+                        "path": "(65003)",
+                    },
+                    {
+                        "valid": True,
+                        "pathFrom": "external",
+                        "path": "(65002)",
+                    },
+                ]
+            }
+        }
+        yield from AssertVtysh.make(
+            r1,
+            "bgpd",
+            f"show bgp ipv4 unicast json",
+            maxwait=5.0,
+            compare=expected,
+        )

--- a/topotato/generatorwrap.py
+++ b/topotato/generatorwrap.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Optional,
     TypeVar,
+    Type,
 )
 
 
@@ -104,7 +105,7 @@ class GeneratorChecks:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         tb: Optional[TracebackType],
     ):


### PR DESCRIPTION
**( Work In Progress )**
There seems to be an issue with the R1 config. R1 is blocking any packets it receives.

Here's the test result:

```
➜  basetato4 git:(bgp-confederation-astype) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x test_bgp_confederation_astype.py
======================================================================================= topotato initialization ========================================================================================

---------------------------------------------------------------------------------------- live log sessionstart -----------------------------------------------------------------------------------------
DEBUG    topotato:pretty.py:145 executable dot found: /usr/bin/dot
DEBUG    topotato:core.py:160 FRR build directory: '/root/buildfrr/'
DEBUG    topotato:core.py:182 FRR source directory: '/root/buildfrr'
INFO     topotato:core.py:226 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:core.py:238 zebra => zebra/zebra
DEBUG    topotato:core.py:236 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:core.py:236 ignoring target 'tools/ssd'
DEBUG    topotato:core.py:238 bgpd => bgpd/bgpd
DEBUG    topotato:core.py:238 ripd => ripd/ripd
DEBUG    topotato:core.py:238 ripngd => ripngd/ripngd
DEBUG    topotato:core.py:238 ospfd => ospfd/ospfd
DEBUG    topotato:core.py:238 ospf6d => ospf6d/ospf6d
DEBUG    topotato:core.py:238 isisd => isisd/isisd
DEBUG    topotato:core.py:238 fabricd => isisd/fabricd
DEBUG    topotato:core.py:238 nhrpd => nhrpd/nhrpd
DEBUG    topotato:core.py:238 ldpd => ldpd/ldpd
DEBUG    topotato:core.py:238 babeld => babeld/babeld
DEBUG    topotato:core.py:238 eigrpd => eigrpd/eigrpd
DEBUG    topotato:core.py:238 pimd => pimd/pimd
DEBUG    topotato:core.py:238 pbrd => pbrd/pbrd
DEBUG    topotato:core.py:238 staticd => staticd/staticd
DEBUG    topotato:core.py:238 bfdd => bfdd/bfdd
DEBUG    topotato:core.py:238 vrrpd => vrrpd/vrrpd
DEBUG    topotato:core.py:238 pathd => pathd/pathd
DEBUG    topotato:core.py:236 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:core.py:236 ignoring target 'lib/clippy'
DEBUG    topotato:core.py:236 ignoring target 'tools/permutations'
DEBUG    topotato:core.py:236 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:core.py:236 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:core.py:236 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:core.py:236 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:core.py:236 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:core.py:236 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:core.py:236 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:92 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:92 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:92 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:92 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4
configfile: pytest.ini
collecting ... ----------------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------------
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_confederation_astype.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<Module test_bgp_confederation_astype.py>, 'BGPConfederationAstype', <class 'test_bgp_confederation_astype.BGPConfederationAstype'>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPConfederationAstype>, 'bgp_converge', <topotato.base.TopotatoWrapped object at 0x7f8623fdf510>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPConfederationAstype>, 'bgp_check_neighbors', <topotato.base.TopotatoWrapped object at 0x7f8621f72310>)
DEBUG    topotato:base.py:277 _topotato_makeitem(<TopotatoClass BGPConfederationAstype>, 'bgp_check_routes', <topotato.base.TopotatoWrapped object at 0x7f8621f72250>)
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_converge> test: <AssertVtysh #132:r1/bgpd/vtysh[show bgp summary json]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_check_neighbors> test: <AssertVtysh #154:r1/bgpd/vtysh[show bgp neighbors json]>
DEBUG    topotato:base.py:676 collect on: <TopotatoFunction bgp_check_routes> test: <AssertVtysh #180:r1/bgpd/vtysh[show bgp ipv4 unicast json]>
collected 5 items                                                                                                                                                                                      

test_bgp_confederation_astype.py::BGPConfederationAstype::startup 
-------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:326 <topotato.network.TopotatoNetwork object at 0x7f8621f77590> tempdir created: /tmp/tmp9eijo7zw
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f8621f77590> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmp9eijo7zw/switch-ns
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f8621f77590> temp-subdir for <FRRRouterNS: 'r3'> created: /tmp/tmp9eijo7zw/r3
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f8621f77590> temp-subdir for <FRRRouterNS: 'r1'> created: /tmp/tmp9eijo7zw/r1
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f8621f77590> temp-subdir for <FRRRouterNS: 'r2'> created: /tmp/tmp9eijo7zw/r2
PASSED (3.53)                                                                                                                                                                                    [ 20%]
test_bgp_confederation_astype.py::BGPConfederationAstype::bgp_converge:#132:r1/bgpd/vtysh[show bgp summary json] FAILED                                                                          [ 40%]

=============================================================================================== FAILURES ===============================================================================================
______________________________________________________________________________ #132:r1/bgpd/vtysh[show bgp summary json] _______________________________________________________________________________

self = <test_bgp_confederation_astype.BGPConfederationAstype object at 0x7f8622ce9410>, _ = None, r1 = <Router 1 "r1">, r2 = <Router 2 "r2">, r3 = <Router 3 "r3">

    @topotatofunc
    def bgp_converge(self, _, r1, r2, r3):
        expected = {
            "ipv4Unicast": {
                "peerCount": 2,
                "peers": {
                    str(r2.iface_to("s1").ip4[0].ip): {
                        "hostname": "r2",
                        "remoteAs": 65002,
                        "localAs": 65001,
                        "pfxRcd": 1,
                        "state": "Established",
                    },
                    str(r3.iface_to("s2").ip4[0].ip): {
                        "hostname": "r3",
                        "remoteAs": 65003,
                        "localAs": 65001,
                        "pfxRcd": 1,
                        "state": "Established",
                    },
                },
            }
        }
>       yield from AssertVtysh.make(
            r1,
            "bgpd",
            f"show bgp summary json",
            maxwait=5.0,
            compare=expected,
        )
E       topotato.exceptions.TopotatoCLICompareFail: json["ipv4Unicast"]["peers"]["192.168.1.2"]["pfxRcd"] dict value is different (
E       --- Expected value
E       +++ Current value
E       @@ -1 +1 @@
E       -1
E       +0)
E       json["ipv4Unicast"]["peers"]["192.168.2.2"]["localAs"] dict value is different (
E       --- Expected value
E       +++ Current value
E       @@ -1 +1 @@
E       -65001
E       +65300)
E       json["ipv4Unicast"]["peers"]["192.168.2.2"]["remoteAs"] dict value is different (
E       --- Expected value
E       +++ Current value
E       @@ -1 +1 @@
E       -65003
E       +65300)
E       json["ipv4Unicast"]["peers"]["192.168.2.2"]["pfxRcd"] dict value is different (
E       --- Expected value
E       +++ Current value
E       @@ -1 +1 @@
E       -1
E       +0)

/root/basetato4/test_bgp_confederation_astype.py:132: TopotatoCLICompareFail
=========================================================================================== warnings summary ===========================================================================================
../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)

../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================= short test summary info ========================================================================================
FAILED test_bgp_confederation_astype.py::BGPConfederationAstype::bgp_converge:#132:r1/bgpd/vtysh[show bgp summary json] - topotato.exceptions.TopotatoCLICompareFail: json["ipv4Unicast"]["peers"]["192.168.1.2"]["pfxRcd"] dict value is different (
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=============================================================================== 1 failed, 1 passed, 2 warnings in 9.10s ================================================================================

```