### PR TITLE
topotato: test_bgp_maximum_prefix_invalid_update.py

### DIFF
--- a/test_bgp_maximum_prefix_invalid_update.py
+++ b/test_bgp_maximum_prefix_invalid_update.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2023 Nathan Mangar
+
+"""
+bgp_maximum_prefix_invalid_update.py:
+Test if unnecesarry UPDATE message like below:
+
+[Error] Error parsing NLRI
+%NOTIFICATION: sent to neighbor X.X.X.X 3/10 (UPDATE Message Error/Invalid Network Field) 0 bytes
+
+is not sent if maximum-prefix count is overflow.
+"""
+
+__topotests_file__ = (
+    "bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py"
+)
+__topotests_gitrev__ = "acddc0ed3ce0833490b7ef38ed000d54388ebea4"
+
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring, line-too-long, consider-using-f-string, wildcard-import, unused-wildcard-import, f-string-without-interpolation, too-few-public-methods, unused-argument
+
+from topotato import *
+
+
+@topology_fixture()
+def topology(topo):
+    """
+    [ r1 ]
+      |
+    { s1 }
+      |
+    [ r2 ]
+    """
+
+    topo.router("r1").lo_ip4.append("172.16.255.254/32")
+    topo.router("r1").lo_ip4.append("172.16.255.253/32")
+
+
+class Configs(FRRConfigs):
+    routers = ["r1", "r2"]
+
+    zebra = """
+    #% extends "boilerplate.conf"
+    #% block main
+    #%   for iface in router.ifaces
+    interface {{ iface.ifname }}
+     ip address {{ iface.ip4[0] }}
+    !
+    #%   endfor
+    ip forwarding
+    !
+    #% endblock
+    """
+
+    bgpd = """
+    #% block main
+    #%   if router.name == 'r1'
+    router bgp 65000
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} remote-as 65001
+     neighbor {{ routers.r2.iface_to('s1').ip4[0].ip }} timers 3 10
+     address-family ipv4 unicast
+      redistribute connected
+     exit-address-family
+     !
+    !
+    ip prefix-list r2 seq 5 permit {{ routers.r1.lo_ip4[0] }}
+    ip prefix-list r2 seq 10 permit {{ routers.r1.lo_ip4[0] }}
+    !
+    #%   elif router.name == 'r2'
+    router bgp 65001
+     no bgp ebgp-requires-policy
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} remote-as 65000
+     neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} timers 3 10
+     address-family ipv4
+      neighbor {{ routers.r1.iface_to('s1').ip4[0].ip }} maximum-prefix 1
+     exit-address-family
+     !
+    !
+    #%   endif
+    #% endblock
+    """
+
+
+class BGPIpv4ClassEPeer(TestBase, AutoFixture, topo=topology, configs=Configs):
+    @topotatofunc
+    def bgp_parsing_nlri(self, r1, r2):
+        expected = {
+            str(r1.iface_to("s1").ip4[0].ip): {
+                "lastNotificationReason": "Cease/Maximum Number of Prefixes Reached",
+                "lastResetDueTo": "BGP Notification send",
+            }
+        }
+        yield from AssertVtysh.make(
+            r2,
+            "bgpd",
+            f"show ip bgp neighbor {r1.iface_to('s1').ip4[0].ip} json",
+            maxwait=5.0,
+            compare=expected,
+        )


### PR DESCRIPTION
**Test Result**

```
➜  basetato4 git:(bgp-maximum-prefix-invalid-update) ✗ ./run_userns.sh --frr-builddir=/root/buildfrr/ --log-cli-level=DEBUG -v -v  -x --pause-on-fail test_bgp_maximum_prefix_invalid_update.py
============================================ topotato initialization =============================================

--------------------------------------------- live log sessionstart ----------------------------------------------
DEBUG    topotato:pretty.py:145 executable dot found: /usr/bin/dot
DEBUG    topotato:core.py:170 FRR build directory: '/root/buildfrr/'
DEBUG    topotato:core.py:192 FRR source directory: '/root/buildfrr'
INFO     topotato:core.py:236 FRR daemons: zebra, staticd, babeld, bfdd, bgpd, eigrpd, fabricd, isisd, ldpd, nhrpd, ospf6d, ospfd, pathd, pbrd, pim6d, pimd, ripd, ripngd, vrrpd
DEBUG    topotato:core.py:248 zebra => zebra/zebra
DEBUG    topotato:core.py:246 ignoring target 'watchfrr/watchfrr'
DEBUG    topotato:core.py:246 ignoring target 'tools/ssd'
DEBUG    topotato:core.py:248 bgpd => bgpd/bgpd
DEBUG    topotato:core.py:248 ripd => ripd/ripd
DEBUG    topotato:core.py:248 ripngd => ripngd/ripngd
DEBUG    topotato:core.py:248 ospfd => ospfd/ospfd
DEBUG    topotato:core.py:248 ospf6d => ospf6d/ospf6d
DEBUG    topotato:core.py:248 isisd => isisd/isisd
DEBUG    topotato:core.py:248 fabricd => isisd/fabricd
DEBUG    topotato:core.py:248 nhrpd => nhrpd/nhrpd
DEBUG    topotato:core.py:248 ldpd => ldpd/ldpd
DEBUG    topotato:core.py:248 babeld => babeld/babeld
DEBUG    topotato:core.py:248 eigrpd => eigrpd/eigrpd
DEBUG    topotato:core.py:248 pimd => pimd/pimd
DEBUG    topotato:core.py:248 pbrd => pbrd/pbrd
DEBUG    topotato:core.py:248 staticd => staticd/staticd
DEBUG    topotato:core.py:248 bfdd => bfdd/bfdd
DEBUG    topotato:core.py:248 vrrpd => vrrpd/vrrpd
DEBUG    topotato:core.py:248 pathd => pathd/pathd
DEBUG    topotato:core.py:246 ignoring target 'lib/grammar_sandbox'
DEBUG    topotato:core.py:246 ignoring target 'lib/clippy'
DEBUG    topotato:core.py:246 ignoring target 'tools/permutations'
DEBUG    topotato:core.py:246 ignoring target 'tools/gen_northbound_callbacks'
DEBUG    topotato:core.py:246 ignoring target 'tools/gen_yang_deviations'
DEBUG    topotato:core.py:246 ignoring target 'bgpd/bgp_btoa'
DEBUG    topotato:core.py:246 ignoring target 'bgpd/rfp-example/rfptest/rfptest'
DEBUG    topotato:core.py:246 ignoring target 'ospfclient/ospfclient'
DEBUG    topotato:core.py:246 ignoring target 'pimd/test_igmpv3_join'
DEBUG    topotato:core.py:246 ignoring target 'pceplib/pcep_pcc'
DEBUG    topotato:topolinux.py:92 executable unshare found: /usr/bin/unshare
DEBUG    topotato:topolinux.py:92 executable nsenter found: /usr/bin/nsenter
DEBUG    topotato:topolinux.py:92 executable tini found: /usr/bin/tini
DEBUG    topotato:topolinux.py:92 executable ip found: /usr/sbin/ip
Warning: daemon 'pim6d' not enabled in configure, skipping
============================================== test session starts ===============================================
platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/basetato4
configfile: pytest.ini
collecting ... ---------------------------------------------- live log collection -----------------------------------------------
DEBUG    topotato:base.py:278 _topotato_makeitem(<Module test_bgp_maximum_prefix_invalid_update.py>, 'TestBase', <class 'topotato.base.TestBase'>)
DEBUG    topotato:base.py:278 _topotato_makeitem(<Module test_bgp_maximum_prefix_invalid_update.py>, 'BGPIpv4ClassEPeer', <class 'test_bgp_maximum_prefix_invalid_update.BGPIpv4ClassEPeer'>)
DEBUG    topotato:base.py:278 _topotato_makeitem(<TopotatoClass BGPIpv4ClassEPeer>, 'bgp_parsing_nlri', <topotato.base.TopotatoWrapped object at 0x7f183f8bb0d0>)
DEBUG    topotato:base.py:686 collect on: <TopotatoFunction bgp_parsing_nlri> test: <AssertVtysh #93:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json]>
collected 3 items                                                                                                

test_bgp_maximum_prefix_invalid_update.py::BGPIpv4ClassEPeer::startup 
------------------------------------------------- live log setup -------------------------------------------------
DEBUG    topotato.topolinux:topolinux.py:326 <topotato.network.TopotatoNetwork object at 0x7f183f6730d0> tempdir created: /tmp/tmpwb252bn6
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f183f6730d0> temp-subdir for <SwitchyNS: 'switch-ns'> created: /tmp/tmpwb252bn6/switch-ns
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f183f6730d0> temp-subdir for <FRRRouterNS: 'r1'> created: /tmp/tmpwb252bn6/r1
DEBUG    topotato.topolinux:topolinux.py:114 <topotato.network.TopotatoNetwork object at 0x7f183f6730d0> temp-subdir for <FRRRouterNS: 'r2'> created: /tmp/tmpwb252bn6/r2
PASSED (3.43)                                                                                              [ 33%]
test_bgp_maximum_prefix_invalid_update.py::BGPIpv4ClassEPeer::bgp_parsing_nlri:#93:r2/bgpd/vtysh[show ip bgp neighbor 10.101.0.1 json] PASSED (3.00) [ 66%]
test_bgp_maximum_prefix_invalid_update.py::BGPIpv4ClassEPeer::shutdown Running as user "root" and group "root". This could be dangerous.
tshark: The file "/tmp/topotatooem5fpyh.pcapng" appears to be damaged or corrupt.
(pcapng_read_systemd_journal_export_block: total block length 180 is too small (< 212))
PASSED (1.51)                       [100%]

================================================ warnings summary ================================================
../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)

../../usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870
  /usr/local/lib/python3.11/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================= 3 passed, 2 warnings in 10.67s =========================================
```