### PR TITLE
Topotato: Regex Json Compare Directive

### DIFF
--- a/topotato/__init__.py
+++ b/topotato/__init__.py
@@ -12,6 +12,6 @@ if "TOPOTATO_INNER" not in os.environ:
     from .base import TestBase, topotatofunc
     from .fixtures import *
     from .assertions import *
-    from .utils import JSONCompareIgnoreContent
+    from .utils import JSONCompareIgnoreContent, JSONCompareRegex
 
 del os

--- a/topotato/utils.py
+++ b/topotato/utils.py
@@ -360,7 +360,12 @@ def json_cmp(d1, d2):
 
             if isinstance(nd2[key], JSONCompareDirective):
                 if isinstance(nd2[key], JSONCompareRegex):
-                    if not nd2[key].match(str(nd1[key])):
+                    if not isinstance(nd1[key], str):
+                        result.add_error(
+                            'JSONCompareRegex expects a value of type `str`, received a value of type `{}` ({}) at ["{}"] '.format(
+                                type(nd1[key]).__name__, nd1[key], key)
+                            )
+                    elif not nd2[key].match(nd1[key]):
                         result.add_error(
                             '{}["{}"] dict value is different (\n{} vs regex {})'.format(
                                 parent, key, nd1[key], repr(nd2[key].regex.pattern)

--- a/topotato/utils.py
+++ b/topotato/utils.py
@@ -121,6 +121,32 @@ class JSONCompareDirective(dict):
     """
 
 
+
+
+class JSONCompareRegex(JSONCompareDirective):
+    """
+    Compare this value with a regular expression.
+    
+    :Example:
+    
+        JsonCompareRegex(r"\s+")
+        JsonCompareRegex(r"\d+")
+        JsonCompareRegex("[A-Z]")
+        JsonCompareRegex(r"^%?FRRouting/")
+
+    """
+    regex: re.Pattern
+
+    def __init__(self, regex: str):
+        super().__init__()
+        
+        self.regex = re.compile(regex)
+
+    def match(self, string):
+            return self.regex.match(string)
+        
+
+
 class JSONCompareIgnoreContent(JSONCompareDirective):
     """
     Ignore list/dict content in JSON compare.
@@ -333,6 +359,15 @@ def json_cmp(d1, d2):
                 raise JSONCompareDirectiveWrongSide(nd1[key])
 
             if isinstance(nd2[key], JSONCompareDirective):
+                if isinstance(nd2[key], JSONCompareRegex):
+                    if not nd2[key].match(str(nd1[key])):
+                        result.add_error(
+                            '{}["{}"] dict value is different (\n{} vs regex {})'.format(
+                                parent, key, nd1[key], repr(nd2[key].regex.pattern)
+                            )
+                        )
+                    continue
+
                 if isinstance(nd2[key], JSONCompareIgnoreContent):
                     continue
 

--- a/topotato/v1.py
+++ b/topotato/v1.py
@@ -25,6 +25,7 @@ from .utils import (
     JSONCompareIgnoreContent,
     JSONCompareIgnoreExtraListitems,
     JSONCompareListKeyedDict,
+    JSONCompareRegex
 )
 from .network import (
     TopotatoNetwork,


### PR DESCRIPTION
Usage:

```python

compare = {
   "item": JsonCompareRegex(r"\s+"),
   "item1": JsonCompareRegex(r"\d+"),
   "item2": JsonCompareRegex("[A-Z]+"),
   "item3": JsonCompareRegex(r"^%?FRRouting/")
}
```

Example of errors:

```sh
E       topotato.exceptions.TopotatoCLICompareFail: json["item"] dict value is different (
E       1 vs regex '\\s+')
```
```sh
E       topotato.exceptions.TopotatoCLICompareFail: json["item1"] dict value is different (
E       abcd vs regex '\\d+')
```