### PR TITLE
topotato: add freebsd environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,17 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "ubuntu/jammy64"
+  config.vm.define :freebsd do |freebsd|
+    freebsd.vm.box = "freebsd/FreeBSD-14.0-RELEASE"
+    freebsd.vm.provision "shell", path: "./vm/freebsd/install.sh"
+    # freebsd.vm.provision "shell", path: "./vm/freebsd/topotato-install.sh"
+  end
+
+  config.vm.define :ubuntu do |ubuntu|
+    ubuntu.vm.box = "ubuntu/jammy64"
+    ubuntu.vm.provision "shell", path: "./vm/ubuntu/install.sh"
+    ubuntu.vm.provision "shell", path: "./vm/ubuntu/topotato-install.sh"
+  end
 
   config.vm.hostname = "topotato-dev"
 
@@ -28,8 +38,5 @@ Vagrant.configure("2") do |config|
     config.vbguest.auto_update = false
     config.vbguest.no_remote   = true
   end
-
-  config.vm.provision "shell", path: "./vm/ubuntu/install.sh"
-  config.vm.provision "shell", path: "./vm/ubuntu/topotato-install.sh"
 
 end

--- a/run_jail.sh
+++ b/run_jail.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+cd "`dirname $0`"
+
+if [ \! -d "/usr/local/etc/frr" ]; then
+    echo /usr/local/etc/frr does not exist or is not a directory.  Please create it. >&2
+    exit 1
+fi
+
+if [ "$1" = "ns_inner" ]; then
+
+    shift
+    for I in `ls -1 etc`; do
+        if [ "$I" = "frr" ]; then
+            continue
+        fi
+        mount_nullfs "etc/$I" "/etc/$I"
+    done
+    mount -t tmpfs tmpfs /var/tmp
+    mount -t tmpfs tmpfs /var/run
+
+    # ip link set lo0 up
+
+    exec ${PYTHON:-python} -mpytest "$@"
+else
+    sudo jail -cmr -f ./vm/jail.conf
+    sudo jexec topotato $PWD/$0 ns_inner $@
+    sudo jail -r topotato
+fi

--- a/vm/freebsd/install.sh
+++ b/vm/freebsd/install.sh
@@ -1,0 +1,41 @@
+#!/usr/local/bin/bash
+
+pkg install git autoconf automake libtool gmake json-c pkgconf \
+    bison py39-pytest c-ares py39-sphinx texinfo libunwind libyang2
+
+pw groupadd frr -g 101
+pw groupadd frrvty -g 102
+pw adduser frr -g 101 -u 101 -G 102 -c "FRR suite" \
+    -d /usr/local/etc/frr -s /usr/sbin/nologin
+
+
+cd /home/vagrant
+git clone https://github.com/frrouting/frr.git --single-branch frr
+cd frr
+./bootstrap.sh
+export MAKE=gmake LDFLAGS=-L/usr/local/lib CPPFLAGS=-I/usr/local/include
+./configure \
+    --sysconfdir=/usr/local/etc/frr \
+    --enable-pkgsrcrcdir=/usr/pkg/share/examples/rc.d \
+    --localstatedir=/var/run/frr \
+    --prefix=/usr/local \
+    --enable-multipath=64 \
+    --enable-user=frr \
+    --enable-group=frr \
+    --enable-vty-group=frrvty \
+    --enable-configfile-mask=0640 \
+    --enable-logfile-mask=0640 \
+    --enable-fpm \
+    --with-pkg-git-version \
+    --with-pkg-extra-version=-MyOwnFRRVersion
+gmake
+gmake check
+gmake install
+
+mkdir /usr/local/etc/frr
+touch /usr/local/etc/frr/frr.conf
+
+sysctl -w net.inet.ip.forwarding=1
+sysctl -w net.inet6.ip6.forwarding=1
+
+service sysctl restart

--- a/vm/freebsd/install.sh
+++ b/vm/freebsd/install.sh
@@ -1,7 +1,7 @@
 #!/usr/local/bin/bash
 
-pkg install git autoconf automake libtool gmake json-c pkgconf \
-    bison py39-pytest c-ares py39-sphinx texinfo libunwind libyang2
+pkg install -y git autoconf automake libtool gmake json-c pkgconf \
+    bison py39-pytest c-ares py39-sphinx texinfo libunwind libyang2 protobuf-c
 
 pw groupadd frr -g 101
 pw groupadd frrvty -g 102

--- a/vm/freebsd/topotato-install.sh
+++ b/vm/freebsd/topotato-install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /home/vagrant/dev/topotato
+# TODO: Add packages for topotato

--- a/vm/jail.conf
+++ b/vm/jail.conf
@@ -1,0 +1,6 @@
+topotato {
+    allow.mount;
+    allow.mount.nullfs;
+    allow.mount.tmpfs;
+    persist;
+}


### PR DESCRIPTION
- topotato: add environment for freebsd using vagrant
- topotato: add scripts for vagrant

### Usage
`vagrant up freebsd`

### Changes
previously, we could run `vagrant up` as is. now you need to specify the type.

currently we have: ubuntu, freebsd

`vagrant up freebsd`
`vagrant up ubuntu`

