### PR TITLE
topotato: add valgrind support and check for memory leaks

### DIFF
--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -1,0 +1,88 @@
+{
+   <zlog_keep_working_at_exit>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:qcalloc
+   fun:zlog_target_clone
+}
+{
+   <libyang1_1.0.184>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_dlerror_run
+   fun:dlopen@@GLIBC_2.2.5
+   obj:/usr/lib/x86_64-linux-gnu/libyang.so.1.9.2
+   fun:ly_load_plugins
+}
+{
+   <zprivs_init leak in a function we do not control>
+   Memcheck:Leak
+   fun:calloc
+   fun:cap_init
+   fun:zprivs_caps_init
+}
+{
+   <sqlite3 leak in a function we do not control>
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:sqlite3_step
+}
+{
+   <libyang2 prefix_data stuff>
+   Memcheck:Leak
+   fun:calloc
+   fun:ly_store_prefix_data
+   ...
+   fun:yang_module_load
+}
+{
+   <libyang2 lys_compile_type_union>
+   Memcheck:Leak
+   fun:realloc
+   fun:lys_compile_type_union
+   ...
+   fun:yang_module_load
+}
+{
+   <libyang2 pcre2_compile>
+   Memcheck:Leak
+   fun:malloc
+   fun:pcre2_compile_8
+   ...
+   fun:yang_module_load
+}
+{
+   <libyang2 lys_compile_type_patterns malloc>
+   Memcheck:Leak
+   fun:malloc
+   fun:lys_compile_type_patterns
+   ...
+   fun:yang_module_load
+}
+{
+   <libyang2 lys_compile_type_patterns calloc>
+   Memcheck:Leak
+   fun:calloc
+   fun:lys_compile_type_patterns
+   ...
+   fun:yang_module_load
+}
+{
+   <libyang2 lys_compile_type>
+   Memcheck:Leak
+   fun:calloc
+   fun:lys_compile_type
+   ...
+   fun:yang_module_load
+}
+{
+   <libyang2 lys_compile_type_range>
+   Memcheck:Leak
+   ...
+   fun:lys_compile_type_range
+   ...
+   fun:yang_module_load
+}

--- a/topotato/frr/core.py
+++ b/topotato/frr/core.py
@@ -526,7 +526,6 @@ class FRRRouterNS(TopotatoNetwork.RouterNS, CallableNS):
     rundir: Optional[str]
     rtrcfg: Dict[str, str]
     livelogs: Dict[str, LiveLog]
-
     def __init__(
         self, instance: TopotatoNetwork, name: str, configs: _FRRConfigProtocol
     ):
@@ -614,6 +613,32 @@ class FRRRouterNS(TopotatoNetwork.RouterNS, CallableNS):
 
         execpath = os.path.join(frrpath, binmap[daemon])
         cmdline = []
+        
+        # Add valgrind 
+        
+        this_dir = os.path.dirname(
+                        os.path.abspath(os.path.realpath(__file__))
+                    )
+        
+        supp_file = os.path.abspath(
+            os.path.join(this_dir, "../../tools/valgrind.supp")
+        )
+        
+        cmdline.extend(
+            [
+                "valgrind",
+                # "--leak-check=full",
+                # "--show-leak-kinds=all",
+                "--track-origins=yes",
+                "--trace-children=yes",
+                "--num-callers=50",
+                "--gen-suppressions=all",
+                "--expensive-definedness-checks=yes",
+                "--error-exitcode=1",
+                "--suppressions=%s" % supp_file,
+                "--log-file=%s" % self.tempfile(daemon + ".valgrind.log"),
+            ]
+        )
 
         cmdline.extend(
             [

--- a/vm/ubuntu/install.sh
+++ b/vm/ubuntu/install.sh
@@ -8,7 +8,10 @@ sudo apt-get install \
    python3-pytest python3-scapy python3-exabgp \
    install-info build-essential libsnmp-dev perl linux-modules-extra-`uname -r` \
    libcap-dev python2 libelf-dev libunwind-dev cmake libpcre2-dev \
-   protobuf-c-compiler libprotobuf-c-dev libzmq5 libzmq3-dev -y
+   protobuf-c-compiler libprotobuf-c-dev libzmq5 libzmq3-dev libc6-i386 libc6-dbg -y
+
+# install valgrind after installing the dependencies
+sudo apt install valgrind -y
 
 cd /tmp
 git clone https://github.com/CESNET/libyang.git


### PR DESCRIPTION
- Whenever a test is executed, each daemon inside a router will run with valgrind attached. Example BGPD in r1, or r2 will run with valgrind behind, then we wait for the test to finish (ie waiting the daemon to be killed) before checking if there is memory leak.

Things to ponder on:
- The implementation is for demonstration purpose;
   - it could be improved with a `--check-memory-leak` flag
   - we could also use `gdbserver` for example to check per Assertion example, Everytime we do a `AssertVtysh` we look at valgrind, instead of waiting for the whole test to finish. 
- I also saw an implementation where we use `memstats-at-exit` not sure how it _can_ correlate with valgrind.
- For now if there is a memory leak, it just exit with an error and display the content of valgrind, Maybe there is another way or it should be integrated inside `reportato`
- Not sure of the behaviour of Valgrind inside a namespace (or a jail in freebsd) if there is overhead or there is false positive.


