### PR TITLE
vtysh, lib: fix 'show ip[v6] prefix-list ... json' JSON display by moving it to vtysh to fix formatting issue "#1"

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1073,17 +1073,13 @@ static int vty_show_prefix_list(struct vty *vty, afi_t afi, const char *name,
 	struct prefix_master *master;
 	int64_t seqnum = 0;
 	json_object *json = NULL;
-	json_object *json_proto = NULL;
 
 	master = prefix_master_get(afi, 0);
 	if (master == NULL)
 		return CMD_WARNING;
 
-	if (uj) {
+	if (uj)
 		json = json_object_new_object();
-		json_proto = json_object_new_object();
-		json_object_object_add(json, frr_protoname, json_proto);
-	}
 
 	if (seq)
 		seqnum = (int64_t)atol(seq);
@@ -1096,8 +1092,8 @@ static int vty_show_prefix_list(struct vty *vty, afi_t afi, const char *name,
 					"%% Can't find specified prefix-list\n");
 			return CMD_WARNING;
 		}
-		vty_show_prefix_entry(vty, json_proto, afi, plist, master,
-				      dtype, seqnum);
+		vty_show_prefix_entry(vty, json, afi, plist, master, dtype,
+				      seqnum);
 	} else {
 		if (dtype == detail_display || dtype == summary_display) {
 			if (master->recent && !uj)
@@ -1107,8 +1103,8 @@ static int vty_show_prefix_list(struct vty *vty, afi_t afi, const char *name,
 		}
 
 		frr_each (plist, &master->str, plist)
-			vty_show_prefix_entry(vty, json_proto, afi, plist,
-					      master, dtype, seqnum);
+			vty_show_prefix_entry(vty, json, afi, plist, master,
+					      dtype, seqnum);
 	}
 
 	return vty_json(vty, json);
@@ -1227,7 +1223,7 @@ static int vty_clear_prefix_list(struct vty *vty, afi_t afi, const char *name,
 
 #include "lib/plist_clippy.c"
 
-DEFPY (show_ip_prefix_list,
+DEFPY_NOSH (show_ip_prefix_list,
        show_ip_prefix_list_cmd,
        "show ip prefix-list [PREFIXLIST4_NAME$name [seq$dseq (1-4294967295)$arg]] [json$uj]",
        SHOW_STR
@@ -1239,6 +1235,7 @@ DEFPY (show_ip_prefix_list,
        JSON_STR)
 {
 	enum display_type dtype = normal_display;
+
 	if (dseq)
 		dtype = sequential_display;
 
@@ -1258,6 +1255,7 @@ DEFPY (show_ip_prefix_list_prefix,
        "First matched prefix\n")
 {
 	enum display_type dtype = normal_display;
+
 	if (dl)
 		dtype = longer_display;
 	else if (dfm)
@@ -1267,7 +1265,7 @@ DEFPY (show_ip_prefix_list_prefix,
 					   dtype);
 }
 
-DEFPY (show_ip_prefix_list_summary,
+DEFPY_NOSH (show_ip_prefix_list_summary,
        show_ip_prefix_list_summary_cmd,
        "show ip prefix-list summary [PREFIXLIST4_NAME$name] [json$uj]",
        SHOW_STR
@@ -1281,7 +1279,7 @@ DEFPY (show_ip_prefix_list_summary,
 				    summary_display, !!uj);
 }
 
-DEFPY (show_ip_prefix_list_detail,
+DEFPY_NOSH (show_ip_prefix_list_detail,
        show_ip_prefix_list_detail_cmd,
        "show ip prefix-list detail [PREFIXLIST4_NAME$name] [json$uj]",
        SHOW_STR
@@ -1307,7 +1305,7 @@ DEFPY (clear_ip_prefix_list,
 	return vty_clear_prefix_list(vty, AFI_IP, name, prefix_str);
 }
 
-DEFPY (show_ipv6_prefix_list,
+DEFPY_NOSH(show_ipv6_prefix_list,
        show_ipv6_prefix_list_cmd,
        "show ipv6 prefix-list [PREFIXLIST6_NAME$name [seq$dseq (1-4294967295)$arg]] [json$uj]",
        SHOW_STR
@@ -1319,6 +1317,7 @@ DEFPY (show_ipv6_prefix_list,
        JSON_STR)
 {
 	enum display_type dtype = normal_display;
+
 	if (dseq)
 		dtype = sequential_display;
 
@@ -1338,6 +1337,7 @@ DEFPY (show_ipv6_prefix_list_prefix,
        "First matched prefix\n")
 {
 	enum display_type dtype = normal_display;
+
 	if (dl)
 		dtype = longer_display;
 	else if (dfm)
@@ -1347,7 +1347,7 @@ DEFPY (show_ipv6_prefix_list_prefix,
 					   prefix_str, dtype);
 }
 
-DEFPY (show_ipv6_prefix_list_summary,
+DEFPY_NOSH (show_ipv6_prefix_list_summary,
        show_ipv6_prefix_list_summary_cmd,
        "show ipv6 prefix-list summary [PREFIXLIST6_NAME$name] [json$uj]",
        SHOW_STR
@@ -1361,7 +1361,7 @@ DEFPY (show_ipv6_prefix_list_summary,
 				    summary_display, !!uj);
 }
 
-DEFPY (show_ipv6_prefix_list_detail,
+DEFPY_NOSH (show_ipv6_prefix_list_detail,
        show_ipv6_prefix_list_detail_cmd,
        "show ipv6 prefix-list detail [PREFIXLIST6_NAME$name] [json$uj]",
        SHOW_STR

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3474,6 +3474,161 @@ DEFPY (show_route_map,
 	return CMD_SUCCESS;
 }
 
+static void show_prefix_list_send(afi_t afi, const char *prefix_list,
+				  const char *seq, enum display_type dtype,
+				  bool json)
+{
+	unsigned int i;
+	bool first = true;
+	char command_line[128];
+
+	if (afi == AFI_IP)
+		snprintf(command_line, sizeof(command_line),
+			 "do show ip prefix-list ");
+	else if (afi == AFI_IP6)
+		snprintf(command_line, sizeof(command_line),
+			 "do show ipv6 prefix-list ");
+	if (dtype == detail_display)
+		strlcat(command_line, "detail ", sizeof(command_line));
+	else if (dtype == summary_display)
+		strlcat(command_line, "summary ", sizeof(command_line));
+	if (prefix_list)
+		strlcat(command_line, prefix_list, sizeof(command_line));
+	if (dtype == sequential_display) {
+		strlcat(command_line, " seq ", sizeof(command_line));
+		strlcat(command_line, seq, sizeof(command_line));
+	}
+	if (json)
+		strlcat(command_line, " json", sizeof(command_line));
+
+	if (json)
+		vty_out(vty, "{");
+
+	for (i = 0; i < array_size(vtysh_client); i++) {
+		const struct vtysh_client *client = &vtysh_client[i];
+		bool is_connected = true;
+
+		if (!CHECK_FLAG(client->flag, VTYSH_PREFIX_LIST_SHOW))
+			continue;
+
+		for (; client; client = client->next)
+			if (client->fd < 0)
+				is_connected = false;
+
+		if (!is_connected)
+			continue;
+
+		if (json && !first)
+			vty_out(vty, ",");
+		else
+			first = false;
+
+		if (json)
+			vty_out(vty, "\"%s\":", vtysh_client[i].name);
+
+		vtysh_client_execute_name(vtysh_client[i].name, command_line);
+	}
+
+	if (json)
+		vty_out(vty, "}\n");
+}
+
+DEFPY (show_ip_prefix_list,
+       show_ip_prefix_list_cmd,
+       "show ip prefix-list [PREFIXLIST4_NAME$name [seq$dseq (1-4294967295)$arg]] [json$uj]",
+       SHOW_STR
+       IP_STR
+       PREFIX_LIST_STR
+       "Name of a prefix list\n"
+       "sequence number of an entry\n"
+       "Sequence number\n"
+       JSON_STR)
+{
+	enum display_type dtype = normal_display;
+
+	if (dseq)
+		dtype = sequential_display;
+
+	show_prefix_list_send(AFI_IP, name, arg_str, dtype, !!uj);
+	return CMD_SUCCESS;
+}
+
+DEFPY (show_ip_prefix_list_summary,
+       show_ip_prefix_list_summary_cmd,
+       "show ip prefix-list summary [PREFIXLIST4_NAME$name] [json$uj]",
+       SHOW_STR
+       IP_STR
+       PREFIX_LIST_STR
+       "Summary of prefix lists\n"
+       "Name of a prefix list\n"
+       JSON_STR)
+{
+	show_prefix_list_send(AFI_IP, name, NULL, summary_display, !!uj);
+	return CMD_SUCCESS;
+}
+
+DEFPY (show_ip_prefix_list_detail,
+       show_ip_prefix_list_detail_cmd,
+       "show ip prefix-list detail [PREFIXLIST4_NAME$name] [json$uj]",
+       SHOW_STR
+       IP_STR
+       PREFIX_LIST_STR
+       "Detail of prefix lists\n"
+       "Name of a prefix list\n"
+       JSON_STR)
+{
+	show_prefix_list_send(AFI_IP, name, NULL, detail_display, !!uj);
+	return CMD_SUCCESS;
+}
+
+DEFPY (show_ipv6_prefix_list,
+       show_ipv6_prefix_list_cmd,
+       "show ipv6 prefix-list [PREFIXLIST6_NAME$name [seq$dseq (1-4294967295)$arg]] [json$uj]",
+       SHOW_STR
+       IPV6_STR
+       PREFIX_LIST_STR
+       "Name of a prefix list\n"
+       "sequence number of an entry\n"
+       "Sequence number\n"
+       JSON_STR)
+{
+	enum display_type dtype = normal_display;
+
+	if (dseq)
+		dtype = sequential_display;
+
+	show_prefix_list_send(AFI_IP6, name, arg_str, dtype, !!uj);
+	return CMD_SUCCESS;
+}
+
+DEFPY (show_ipv6_prefix_list_summary,
+       show_ipv6_prefix_list_summary_cmd,
+       "show ipv6 prefix-list summary [PREFIXLIST6_NAME$name] [json$uj]",
+       SHOW_STR
+       IPV6_STR
+       PREFIX_LIST_STR
+       "Summary of prefix lists\n"
+       "Name of a prefix list\n"
+       JSON_STR)
+{
+	show_prefix_list_send(AFI_IP6, name, NULL, summary_display, !!uj);
+	return CMD_SUCCESS;
+}
+
+DEFPY (show_ipv6_prefix_list_detail,
+       show_ipv6_prefix_list_detail_cmd,
+       "show ipv6 prefix-list detail [PREFIXLIST6_NAME$name] [json$uj]",
+       SHOW_STR
+       IPV6_STR
+       PREFIX_LIST_STR
+       "Detail of prefix lists\n"
+       "Name of a prefix list\n"
+       JSON_STR)
+{
+	show_prefix_list_send(AFI_IP6, name, NULL, detail_display, !!uj);
+	return CMD_SUCCESS;
+}
+
 DEFUN (vtysh_integrated_config,
        vtysh_integrated_config_cmd,
        "service integrated-vtysh-config",
@@ -3498,8 +3653,8 @@ DEFUN (no_vtysh_integrated_config,
 static void backup_config_file(const char *fbackup)
 {
 	char *integrate_sav = NULL;
-
 	size_t integrate_sav_sz = strlen(fbackup) + strlen(CONF_BACKUP_EXT) + 1;
+
 	integrate_sav = malloc(integrate_sav_sz);
 	strlcpy(integrate_sav, fbackup, integrate_sav_sz);
 	strlcat(integrate_sav, CONF_BACKUP_EXT, integrate_sav_sz);
@@ -5074,6 +5229,12 @@ void vtysh_init_vty(void)
 	install_element(ENABLE_NODE, &vtysh_copy_to_running_cmd);
 
 	install_element(ENABLE_NODE, &show_route_map_cmd);
+	install_element(ENABLE_NODE, &show_ip_prefix_list_cmd);
+	install_element(ENABLE_NODE, &show_ip_prefix_list_summary_cmd);
+	install_element(ENABLE_NODE, &show_ip_prefix_list_detail_cmd);
+	install_element(ENABLE_NODE, &show_ipv6_prefix_list_cmd);
+	install_element(ENABLE_NODE, &show_ipv6_prefix_list_summary_cmd);
+	install_element(ENABLE_NODE, &show_ipv6_prefix_list_detail_cmd);
 
 	/* "write terminal" command. */
 	install_element(ENABLE_NODE, &vtysh_write_terminal_cmd);

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -68,6 +68,10 @@ extern struct event_loop *master;
 	VTYSH_ZEBRA | VTYSH_RIPD | VTYSH_RIPNGD | VTYSH_OSPFD | VTYSH_OSPF6D | \
 		VTYSH_BGPD | VTYSH_ISISD | VTYSH_PIMD | VTYSH_EIGRPD |         \
 		VTYSH_FABRICD
+#define VTYSH_PREFIX_LIST_SHOW                                                 \
+	VTYSH_ZEBRA | VTYSH_RIPD | VTYSH_RIPNGD | VTYSH_OSPFD | VTYSH_OSPF6D | \
+		VTYSH_BGPD | VTYSH_ISISD | VTYSH_PIMD | VTYSH_EIGRPD |         \
+		VTYSH_FABRICD
 #define VTYSH_INTERFACE_SUBSET                                                 \
 	VTYSH_OSPFD | VTYSH_OSPF6D | \
 		VTYSH_ISISD | VTYSH_PIMD | VTYSH_PIM6D | VTYSH_NHRPD |         \
@@ -90,7 +94,17 @@ enum vtysh_write_integrated {
 	WRITE_INTEGRATED_YES
 };
 
+enum display_type {
+	normal_display,
+	summary_display,
+	detail_display,
+	sequential_display,
+	longer_display,
+	first_match_display
+};
+
 extern enum vtysh_write_integrated vtysh_write_integrated;
+extern enum display_type display_type;
 
 extern char frr_config[];
 extern char vtydir[];


### PR DESCRIPTION
Json output is not valid for `show ip prefix-list ... json` commands, because it goes through each running daemon and for each one it calls `vty_show_prefix_list` creating a new json object. To aggregate the output and create a valid json that can be parsed, the commands were moved to vtysh, similarly to this PR: #14856
This solves: #15277

**Before:**
```json
{
  "ZEBRA":{
    "DEFAULT":{
      "addressFamily":"IPv4",
      "entries":[
        {
          "sequenceNumber":10,
          "type":"permit",
          "prefix":"0.0.0.0/0"
        }
      ]
    }
  }
}
{
  "OSPF":{
    "DEFAULT":{
      "addressFamily":"IPv4",
      "entries":[
        {
          "sequenceNumber":10,
          "type":"permit",
          "prefix":"0.0.0.0/0"
        }
      ]
    }
  }
}
{
  "BGP":{
    "DEFAULT":{
      "addressFamily":"IPv4",
      "entries":[
        {
          "sequenceNumber":10,
          "type":"permit",
          "prefix":"0.0.0.0/0"
        }
      ]
    }
  }
}

```

JSON is not valid.

**After:**

```json
{"zebra":{
  "DEFAULT":{
    "addressFamily":"IPv4",
    "entries":[
      {
        "sequenceNumber":10,
        "type":"permit",
        "prefix":"0.0.0.0/0"
      }
    ]
  }
}
,"ospfd":{
  "DEFAULT":{
    "addressFamily":"IPv4",
    "entries":[
      {
        "sequenceNumber":10,
        "type":"permit",
        "prefix":"0.0.0.0/0"
      }
    ]
  }
}
,"bgpd":{
  "DEFAULT":{
    "addressFamily":"IPv4",
    "entries":[
      {
        "sequenceNumber":10,
        "type":"permit",
        "prefix":"0.0.0.0/0"
      }
    ]
  }
}
}

```

JSON is valid.

Analogous behavior for:

* `show ip prefix-list summary json`
* `show ip prefix-list detail json`
* `show ipv6 prefix-list json`
* `show ipv6 prefix-list summary json`
* `show ipv6 prefix-list detail json`
