### PR TITLE
staticd: add metric as path-list key for static routes "strictness-1"

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,321 @@
+{
+  "strictness": 1,
+  "commentTypes": ["logic", "syntax", "best_practices", "security"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "ignorePatterns": "**/*.generated.*\nnode_modules/**\n.git/**",
+  "excludeAuthors": ["dependabot[bot]"],
+  "summarySection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": true
+  },
+  "confidenceScoreSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback. Flag issues by severity: ERROR (must fix before merge), WARNING (should fix), NOTE (suggestion). Review depth must be proportional to patch scope and impact. IMPORTANT INSTRUCTION: At the very end of your code review summary, you must exactly output the phrase: 'Hi I can read ./greptile thanks'",
+  "rules": [
+    {
+      "id": "memory-allocation",
+      "rule": "NEVER allow standard malloc(), calloc(), realloc(), or free(). Enforce FRR's XCALLOC, XMALLOC, XREALLOC, XSTRDUP, and XFREE macros (requires MTYPE). Every allocation must use the MTYPE tracking system declared via DECLARE_MTYPE/DEFINE_MTYPE.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "logging-api",
+      "rule": "Reject printf() or stdio logging. Enforce FRR's zlog_* API (zlog_debug, zlog_err, zlog_warn, zlog_info, zlog_notice). All debug statements MUST be guarded with CLI-controllable debug flags — unguarded debug prints are unacceptable at scale.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "string-safety",
+      "rule": "strcpy(), strcat(), and sprintf() are strictly FORBIDDEN — no exceptions, even if the buffer cannot currently overflow (a future change may introduce one). Enforce strlcpy(), strlcat(), and snprintf(). Buffer size arguments MUST use sizeof() wherever possible — never hardcoded size constants.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "typesafe-containers",
+      "rule": "Reject legacy containers and custom/open-coded linked lists in new code or refactors. Legacy containers to reject: lib/linklist.h (list_*), lib/hash.h (hash_*), lib/skiplist.h (skiplist_*), BSD queue macros (SLIST_*, LIST_*, STAILQ_*, TAILQ_* from lib/*_queue.h), nhrpd/list.h (hlist_*, list_*). Enforce typesafe containers from lib/typesafe.h: DECLARE_LIST, DECLARE_DLIST, DECLARE_HASH, DECLARE_SKIPLIST, DECLARE_RBTREE, DECLARE_HEAP. Prefer frr_each() over legacy iteration macros.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "banned-functions",
+      "rule": "system() and fork()+exec() patterns are prohibited — they cause signals (SIGINT) to be ignored, which breaks daemon shutdown. Flag as ERROR.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "zero-initialization",
+      "rule": "Prefer initializer expressions (e.g., 'struct foo bar = {};') over memset() for stack-allocated structs and arrays. This prevents missed memset() in branches and eliminates incorrect size arguments. Do NOT zero-initialize values that must be nonzero to be used.",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "fixed-width-types",
+      "rule": "Reject legacy types in new code: u_int8_t (use uint8_t), u_int16_t (use uint16_t), u_int32_t (use uint32_t), u_int64_t (use uint64_t), u_char (use uint8_t or unsigned char), u_short (use unsigned short), u_int (use unsigned int), u_long (use unsigned long).",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "cli-defpy",
+      "rule": "New CLI commands MUST use DEFPY macros (not DEFUN). New CLI commands MUST have documentation. If the daemon is already (even partially) YANGified, new CLI options MUST go through a YANG model — zero exceptions.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "config-preference",
+      "rule": "When adding new knobs, prefer (in order): (1) YANG runtime config, (2) CLI runtime config, (3) loadable modules for new library dependencies, (4) command-line startup options (only for pre-config-load effects), (5) ./configure compile-time options (absolute last resort). Avoid new ./configure flags when possible.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "const-correctness",
+      "rule": "Encourage use of 'const' on function parameters and return types where possible for API clarity and safety, especially in lib/ APIs.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "strict-prototypes",
+      "rule": "Functions with no parameters MUST use 'void' in the parameter list: 'static void foo(void)' NOT 'static void foo()'. Without void, C treats it as unspecified parameters with varargs calling convention.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "compile-conditionals",
+      "rule": "Prefer 'if (SOME_SYMBOL)' over '#ifdef SOME_SYMBOL' so the compiler still checks disabled code paths. Ensure SOME_SYMBOL is always defined via AC_DEFINE. Avoid gratuitous --enable-* configure switches.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "include-order",
+      "rule": "First include in any .c file MUST be <zebra.h> or \"config.h\" (with HAVE_CONFIG_H guard). Never use angle brackets for FRR headers (except <zebra.h> and <assert.h>). Prefer full path includes relative to source root. Order: (1) zebra.h/config.h, (2) system headers, (3) lib/ headers, (4) daemon headers. zebra.h must NOT be included from header files.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "zebra-h-purity",
+      "rule": "Do not add FRR-specific declarations or definitions to zebra.h. That file is an include multiplexer for system headers only. Its current FRR-specific content is a known bug, not a feature.",
+      "scope": ["zebra/zebra.h"],
+      "severity": "high"
+    },
+    {
+      "id": "spdx-license",
+      "rule": "New files MUST have 'SPDX-License-Identifier: GPL-2.0-or-later' and a copyright header with year and author. NEVER remove an existing Copyright line or author name — flag as ERROR. New copyright on existing files goes under a 'Portions:' section.",
+      "scope": ["**/*.c", "**/*.h", "**/*.py", "**/*.cpp"],
+      "severity": "high"
+    },
+    {
+      "id": "yang-schema-license",
+      "rule": ".yang and .proto files require BOTH an SPDX-License-Identifier header AND the full license boilerplate text (not just SPDX). Rationale: these files are likely to be individually copied outside FRR.",
+      "scope": ["**/*.yang", "**/*.proto"],
+      "severity": "high"
+    },
+    {
+      "id": "license-compatibility",
+      "rule": "Code must be GPLv2-or-later (preferred) or any license allowing redistribution under GPLv2 (e.g., MIT). FORBIDDEN to push code that prevents use of GPLv3 license. Apache 2.0 and GPLv2 are incompatible when combined. Flag license-incompatible code as ERROR.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "whitespace-discipline",
+      "rule": "Whitespace-only changes in untouched parts of the code are NOT acceptable in patches that change actual code. Formatting fixes must be in a separate, formatting-only patch. Flag as ERROR.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "frr-block-macros",
+      "rule": "Loop-style macros use 'frr_each_*' naming. Single-run macros use 'frr_with_*' naming. frr_with_* macros MUST always use a { } block even for single statements. Prefer frr_each over legacy iteration macros (ALL_LIST_ELEMENTS, FOREACH_AFI_SAFI) in new code.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "defpy-formatting",
+      "rule": "clang-format mangles DEF* macro invocations. For new files, use tools/indent.py which handles DEFUN/DEFPY correctly. DEFPY_HIDDEN and DEFPY_ATTR should NOT be flagged for 'complex macros should be wrapped in parentheses'.",
+      "scope": ["**/*.c"],
+      "severity": "low"
+    },
+    {
+      "id": "printfrr-usage",
+      "rule": "Use printfrr() instead of printf() and snprintfrr() instead of snprintf() in FRR code. printfrr supports FRR-specific format extensions (%pI4, %pI6, %pFX, %pSU, %pIA, %pEA, %pRN, %pNH, %dPF, %dSO, etc.) checked by the frr-format GCC plugin. Standard printf/snprintf do NOT support these extensions. Prefer correctly-typed variables over casts in printfrr arguments — casts can cause false 'strict match required' warnings from the frr-format plugin. Note: [v]as[n]printfrr() is NOT async-signal-safe (it allocates memory).",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "backwards-compat",
+      "rule": "Changes to CLI and lib/ code should be backwards compatible when reasonable. Purely stylistic renames without functional change should be avoided. Deprecated items must use CPP_NOTICE with CONFDATE. CLI deprecation period is 1 year.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "function-docs",
+      "rule": "Functions exposed in header files MUST have descriptive comments with: return value, parameters, and purpose summary. Kernel-style multiline format required. For new code in lib/, this is a HARD requirement — flag missing function comments in lib/ headers as ERROR.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "global-var-docs",
+      "rule": "All global variables, whether static or not, MUST have a comment describing their use.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "rst-formatting",
+      "rule": "RST files must use correct Sphinx formatting. CLI commands MUST use '.. clicmd::' directive — do not document 'no' form separately, and do not enumerate every variant. Config examples use '.. code-block:: frr'. Indent 3 spaces. Lines wrapped to 80 chars. Header levels: # (parts), * (chapters), = (sections), - (subsections), ^ (subsubsections).",
+      "scope": ["**/*.rst"],
+      "severity": "medium"
+    },
+    {
+      "id": "yang-json-output",
+      "rule": "New JSON output MUST be backed by a YANG model — search for existing models (FRR or IETF) before creating new ones. JSON keys must be camelCased (mapped from YANG kebab-case). Commands with no JSON output produce '{}'. JSON commands include a 'json' keyword at end of CLI.",
+      "scope": ["**/*.yang", "**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "python-formatting",
+      "rule": "All Python code must be formatted with 'black' (reference version 19.10b). Run 'python3 -m black <file>' before committing.",
+      "scope": ["**/*.py"],
+      "severity": "medium"
+    },
+    {
+      "id": "commit-title",
+      "rule": "Commit title must be <= 72 characters (ideally <= 50). Prefixed with subsystem name + colon + space + imperative verb (e.g., 'bgpd: fix crash on peer reset'). Must not end with a period. Must have a Signed-off-by line.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "commit-body",
+      "rule": "Commit body separated from title by blank line. Wrapped to 72 characters. Imperative mood. Must explain purpose and context. Messages consisting entirely of program output are unacceptable.",
+      "scope": ["**/*"],
+      "severity": "medium"
+    },
+    {
+      "id": "squash-policy",
+      "rule": "Before merge, squash: fixup commits, typo fixes, review feedback, WIP commits, merges, and rebases into logical commits.",
+      "scope": ["**/*"],
+      "severity": "medium"
+    },
+    {
+      "id": "testing-required",
+      "rule": "Major new features or significant changes MUST include automated tests within existing CI infrastructure. All CI must pass before merge. Code introducing new static analysis warnings is very unlikely to be merged.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "review-process",
+      "rule": "A PR with any 'Changes requested' review may not be merged. A PR with any negative CI result may not be merged. Authors must NEVER delete or manually dismiss someone else's review comments.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "new-dependencies",
+      "rule": "New library or tool dependencies must be highlighted in the PR description. Must be supported by all FRR platform OSes or provide a way to build without it. Consider encapsulating in a loadable module.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "unnamed-struct-fields",
+      "rule": "FRR uses -fms-extensions for unnamed struct fields. 'struct outer { struct inner; };' and union patterns with unnamed struct fields are acceptable and encouraged where contextually appropriate.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "topotest-coverage",
+      "rule": "When a PR adds or modifies daemon functionality (new features, behavior changes, or non-trivial bug fixes), check whether the PR includes corresponding topotest coverage under tests/topotests/. Evaluate whether the newly added or changed code paths are adequately exercised by the tests in the PR. Cross-reference the changed code paths against existing topotests to determine if the specific daemon behavior being modified is exercised by any test topology. If significant new logic is introduced without any test additions or updates, flag as WARNING: 'New code paths appear untested — are topotests included or planned?' When tests ARE included, also check quality: (1) tests must use pytest framework, (2) Python test code must be formatted with black, (3) tests should validate specific outputs not just 'daemon didn't crash', (4) JSON output tests should use json_cmp for structured comparison. Do NOT flag simple one-line fixes, typo corrections, or documentation-only changes.",
+      "scope": ["**/*.c", "**/*.h", "**/*.py"],
+      "severity": "high"
+    },
+    {
+      "id": "user-docs-cli-changes",
+      "rule": "If the PR adds, removes, or modifies CLI commands, YANG models, or any user-facing interface, ask: 'Have the User Docs (doc/user/) been updated to reflect these changes?' This applies to new DEFPY/DEFUN commands, changed command syntax, new show commands, new JSON output fields, and YANG schema changes. New BGP features go in the BGP chapter, not a new chapter. New protocol daemons get their own chapter. Do NOT ask this for internal-only refactors, simple bug fixes, or changes that do not alter user-visible behavior.",
+      "scope": ["**/*.c", "**/*.h", "**/*.yang", "**/*.rst"],
+      "severity": "high"
+    },
+    {
+      "id": "dev-docs-internal-changes",
+      "rule": "If the PR makes significant changes to internal architecture, data structures, threading model, event loop patterns, or introduces new internal APIs in lib/, ask: 'Have the Developer Docs (doc/developer/) been updated?' This applies to new or changed internal APIs, new container types, new locking patterns, or architectural changes. Do NOT ask this for standard bug fixes, minor refactors, or straightforward feature additions that follow existing patterns.",
+      "scope": ["**/*.c", "**/*.h", "lib/**"],
+      "severity": "medium"
+    },
+    {
+      "id": "packet-parsing-safety",
+      "rule": "Code that parses network packets or protocol messages (stream_get*, STREAM_READABLE, packet buffers, wire format decoding) MUST have explicit bounds checking before every read operation. Verify: (1) remaining buffer length is checked before each field extraction, (2) length fields from wire data are validated against remaining buffer size before use as sizes or loop bounds, (3) no pointer arithmetic on packet buffers without bounds validation, (4) no assumptions about minimum packet size without explicit checks, (5) integer overflow checks when computing sizes from wire data. Flag missing bounds checks as ERROR. This applies to BGP UPDATE/OPEN/NOTIFICATION parsing, OSPF LSA/Hello parsing, IS-IS TLV parsing, ZAPI message parsing, BFD/PIM/LDP/VRRP message handlers, and any code handling data from network peers.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "rcu-safety",
+      "rule": "rcu_read_lock() MUST be held continuously while accessing RCU-protected data — do not release and re-acquire between pointer dereference steps. Never deallocate RCU-protected memory without proper RCU grace period (use rcu_free(), rcu_close(), or rcu_call() — never direct XFREE on RCU-protected data). Use atomic_load()/atomic_store() (C11 atomics) for RCU pointer access — FRR does NOT use Linux kernel rcu_dereference/rcu_assign_pointer. Atomic list operations require rwlock: read lock for all accesses (read, add, remove), write lock as sequence point before deallocation (no instructions between wrlock/unlock). Threads accessing RCU-protected data must register via rcu_thread_prepare/rcu_thread_start/rcu_thread_unprepare. RCU read locks are nestable (depth counter) but at root level incur futex syscall cost. There is no synchronize_rcu() in FRR — use rcu_free/rcu_close/rcu_call for deferred cleanup instead. Flag RCU lock release while still accessing protected data as ERROR.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "assert-usage",
+      "rule": "assert() is for development hints and invariant violations only — it WILL crash the daemon in production. NEVER use assert() for input validation, length checking, security constraints, or protocol message validation. For unhandled internal constraint violations (mismatched pointers, NULL required fields, data corruption), use zlog_err or flog_err with proper error handling, NOT assert. Asserts are acceptable only for conditions that indicate a programming bug, not for conditions caused by external input.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "xfree-no-null-check",
+      "rule": "Do NOT wrap XFREE() calls in 'if (ptr != NULL)' checks. The XFREE macro already handles NULL pointers and additionally sets the pointer to NULL after freeing. Wrapping it is redundant and clutters the code.",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "cli-vty-organization",
+      "rule": "CLI command definitions (DEFPY/DEFUN) MUST be organized in *_vty.c and *_vty.h files. Scattering individual CLI commands across unrelated source files is NOT allowed. Each daemon should consolidate its CLI in dedicated VTY files.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "sizeof-allocation-pattern",
+      "rule": "When allocating memory for a struct, prefer sizeof(*ptr) over sizeof(struct type_name). Example: 'p = XMALLOC(MTYPE_FOO, sizeof(*p))' not 'p = XMALLOC(MTYPE_FOO, sizeof(struct foo))'. This prevents size mismatches when the pointer type changes.",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "mtype-locality",
+      "rule": "Prefer DEFINE_MTYPE_STATIC (file-scoped) over DEFINE_MTYPE (global) for memory types used in a single source file — appropriate for ~80% of cases. Move MTYPEs closer to their usage location rather than centralizing them in a single file.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "northbound-yang-callbacks",
+      "rule": "Northbound callbacks MUST be API-agnostic — they must work regardless of whether the caller is CLI, NETCONF, RESTCONF, or gRPC. Do NOT embed CLI-specific logic in northbound callbacks. Configuration changes MUST be transactional (all-or-nothing). If a daemon is being converted to mgmtd, the frr_yang_module_info struct must be split into frontend and backend arrays.",
+      "scope": ["**/*.c", "**/*.h", "**/*.yang"],
+      "severity": "high"
+    },
+    {
+      "id": "hook-parameter-naming",
+      "rule": "Hook callback parameter names MUST NOT start with 'hook' to avoid collision with the hook infrastructure macros. Use descriptive parameter names related to the callback's purpose.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "event-loop-blocking",
+      "rule": "Event loop callbacks (struct event handlers) MUST NOT block. Long-running operations should use worker pthreads via frr_pthread. Use event_add_read/event_add_write for I/O, event_add_timer for delays. Never use sleep() or blocking I/O in event callbacks. Cross-thread task cancellation MUST use event_cancel_async() — using event_cancel() from a different thread than the event loop owner is unsafe. Only one READ and one WRITE task per file descriptor (second schedule overwrites first). Threads must use frr_pthread wrapper for proper registration with the event loop system.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "container-hash-invariant",
+      "rule": "Never modify the fields used by a hash function or comparison function while an item is inserted in a hash table or sorted container. Doing so silently corrupts the container. Remove the item first, modify, then re-insert.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "container-iteration-safety",
+      "rule": "Never add or remove items from a typesafe container while iterating over it unless using the _safe iteration variant (frr_each_safe). Hash tables that resize during iteration will corrupt iteration state — items may be skipped or visited twice. For hash tables, if modification during iteration is needed, collect items to modify in a separate list first, then apply changes after iteration completes. Container _fini() closes the data structure permanently — any access after _fini() causes an intentional crash. Use frr_each_safe() when deleting items during iteration.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    }
+  ],
+  "disabledRules": []
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,196 @@
+{
+  "files": [
+    {
+      "path": "doc/developer/workflow.rst",
+      "description": "FRR core coding standards, PR requirements, commit message format, review process, release cycle, defensive coding, formatting rules, and architectural guidelines."
+    },
+    {
+      "path": "doc/developer/cli.rst",
+      "description": "CLI/DEFPY command definition standards, VTY node architecture, help string conventions, YANG CLI integration requirements, and *_vty.[ch] organization rules."
+    },
+    {
+      "path": "doc/developer/memtypes.rst",
+      "description": "MTYPE memory tracking system — XMALLOC/XCALLOC/XFREE usage, DECLARE_MTYPE/DEFINE_MTYPE patterns, XFREE NULL-safety, DEFINE_MTYPE_STATIC preference."
+    },
+    {
+      "path": "doc/developer/lists.rst",
+      "description": "Typesafe container API (DECLARE_LIST, DECLARE_HASH, etc.) — required replacement for legacy BSD queue macros and lib/linklist.h. Hash invariant rules, frr_each iteration, atomic list rwlock requirements."
+    },
+    {
+      "path": "doc/developer/logging.rst",
+      "description": "zlog API usage, printfrr format extensions (%pFX, %pI4, %pSU, etc.), debug flag conventions, assert usage policy (no asserts for input validation), log level guidelines (ERROR/WARNING/INFO/DEBUG semantics)."
+    },
+    {
+      "path": "doc/developer/process-architecture.rst",
+      "description": "FRR daemon architecture — event loop (threadmaster/struct event), threading model, frr_pthread, cross-thread scheduling, non-blocking callback requirements."
+    },
+    {
+      "path": "doc/developer/locking.rst",
+      "description": "Locking primitives — frr_with_mutex (requires braces), frr_mutex_lock_autounlock, and concurrency guidelines."
+    },
+    {
+      "path": "doc/developer/rcu.rst",
+      "description": "RCU (Read-Copy-Update) rules — rcu_read_lock continuous hold requirement, rcu_free for delayed deallocation, atomic_load/atomic_store for pointer access, no synchronize_rcu in FRR."
+    },
+    {
+      "path": "doc/developer/hooks.rst",
+      "description": "Hook/callback system — DECLARE_HOOK/DEFINE_HOOK, priority ranges, KOOH reverse-priority hooks, parameter naming restrictions (no 'hook' prefix)."
+    },
+    {
+      "path": "doc/developer/modules.rst",
+      "description": "Loadable module system — FRR_MODULE_SETUP, frr_late_init hook, module:param CLI format, no runtime load/unload, GPL-encumbered licensing."
+    },
+    {
+      "path": "doc/developer/checkpatch.rst",
+      "description": "checkpatch.sh style checker — ERROR vs WARNING classification and known exceptions."
+    },
+    {
+      "path": "doc/developer/vtysh.rst",
+      "description": "VTYSH architecture — how CLI commands are extracted via xref2vtysh.py, DEFSH/DEFUNSH usage, mode synchronization, domain socket protocol.",
+      "scope": ["vtysh/**", "**/*_vty.c", "**/*_vty.h"]
+    },
+    {
+      "path": "doc/developer/topotests.rst",
+      "description": "Topotest framework — pytest requirements, test execution as root, FRR installation paths, test result analysis. Cross-reference when evaluating PR test coverage."
+    },
+    {
+      "path": "doc/developer/testing.rst",
+      "description": "Testing infrastructure overview and CI requirements."
+    },
+    {
+      "path": "doc/developer/northbound/architecture.rst",
+      "description": "Northbound architecture — YANG model-driven management, API-agnostic callbacks, configuration transactions (all-or-nothing), libyang dependency, plugin architecture."
+    },
+    {
+      "path": "doc/developer/northbound/retrofitting-configuration-commands.rst",
+      "description": "How to retrofit existing CLI commands to northbound YANG callbacks. Required reading for daemon mgmtd conversion PRs."
+    },
+    {
+      "path": "doc/developer/northbound/operational-data-rpcs-and-notifications.rst",
+      "description": "Operational data callbacks (get_elem, get_next, get_keys, lookup_entry), RPC callback patterns, YANG notifications, list iteration locking requirements."
+    },
+    {
+      "path": "doc/developer/mgmtd-dev.rst",
+      "description": "Management daemon (mgmtd) conversion guide — frontend/backend split, frr_yang_module_info arrays, BE client initialization, XPATH prefix registration."
+    },
+    {
+      "path": "doc/developer/zebra.rst",
+      "description": "ZAPI protocol versions, daemon-zebra communication, dataplane batching, netlink message format, binary encoding."
+    },
+    {
+      "path": "doc/developer/scripting.rst",
+      "description": "Lua 5.3 scripting interface — frrscript API, security (no Lua stdlib), encoder/decoder patterns, memory ownership rules."
+    },
+    {
+      "path": "doc/developer/fuzzing.rst",
+      "description": "Fuzzing infrastructure — libFuzzer and AFL targets, sanitizer flags, LLVMFuzzerTestOneInput entry points."
+    },
+    {
+      "path": "doc/developer/tracing.rst",
+      "description": "LTTng and USDT tracepoint conventions — frr_ provider prefix, frrtrace macro, daemon trace.[ch] file patterns."
+    },
+    {
+      "path": "doc/developer/path-internals-pcep.rst",
+      "description": "PCEP module threading rules — pcep_ctrl_ (main thread only) vs pcep_thread_ (controller thread only), data copying across threads, strict function prefix conventions.",
+      "scope": ["pathd/**"]
+    },
+    {
+      "path": "doc/developer/link-state.rst",
+      "description": "Link State API — TED graph model, ls_node/ls_attributes/ls_prefix structures, mandatory locking during iteration, ZAPI opaque message protocol.",
+      "scope": ["lib/link_state.*", "ospfd/ospf_ext.*", "isisd/isis_te.*"]
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "description": "Top-level contribution guidelines and PR process overview."
+    },
+    {
+      "path": "doc/developer/bgpd.rst",
+      "description": "BGP daemon internals — UPDATE/OPEN/NOTIFICATION parsing, attribute handling, peer state machine, route processing pipeline. Critical reference for BGP packet parsing security review.",
+      "scope": ["bgpd/**"]
+    },
+    {
+      "path": "doc/developer/ospf.rst",
+      "description": "OSPF daemon internals — LSA parsing, Hello/DD packet handling, SPF computation, area/interface state machines. Reference for OSPF packet parsing security review.",
+      "scope": ["ospfd/**", "ospf6d/**"]
+    },
+    {
+      "path": "doc/developer/northbound/advanced-topics.rst",
+      "description": "Northbound advanced patterns — YANG list iteration locking, transaction error handling, candidate config lifecycle, implicit delete semantics."
+    },
+    {
+      "path": "doc/developer/northbound/transactional-cli.rst",
+      "description": "Transactional CLI mode — candidate configuration model, commit/discard semantics, configuration lock behavior. Required context for CLI transaction PRs."
+    },
+    {
+      "path": "doc/developer/topotest-multicast.rst",
+      "description": "Multicast topotest patterns — PIM/IGMP test topology conventions, multicast route validation, MLD test helpers.",
+      "scope": ["tests/topotests/*multicast*", "tests/topotests/*pim*", "pimd/**", "pim6d/**"]
+    },
+    {
+      "path": "doc/developer/static-linking.rst",
+      "description": "Static linking guidelines — when and how to statically link FRR, implications for module loading and library dependencies."
+    },
+    {
+      "path": "doc/developer/grpc.rst",
+      "description": "gRPC northbound interface — enable via --enable-grpc, module loading with -M grpc:<port>, language bindings (Python, C++, Ruby), channel setup, and gNMI/gNOI integration.",
+      "scope": ["grpc/**", "lib/northbound_grpc.*"]
+    },
+    {
+      "path": "doc/developer/ospf-api.rst",
+      "description": "OSPF API for external application access to the LSDB — client library (ospfclient), synchronous/asynchronous operations, LSA origination and retrieval, callback registration.",
+      "scope": ["ospfd/ospf_api*", "ospfclient/**"]
+    },
+    {
+      "path": "doc/developer/zebra-neigh-api.rst",
+      "description": "Zebra Neighbor API — ARP/NDP state tracking via netlink, ZAPI neighbor messages, client daemon subscription model for IPv4/IPv6 neighbor state changes.",
+      "scope": ["zebra/zebra_neigh.*", "lib/zclient.*"]
+    },
+    {
+      "path": "doc/developer/next-hop-tracking.rst",
+      "description": "Next Hop Tracking (NHT) — BGP bestpath optimization via routing table monitoring, recursive route resolution, nexthop registration/notification between BGP and Zebra.",
+      "scope": ["bgpd/bgp_nht.*", "zebra/zebra_rnh.*"]
+    },
+    {
+      "path": "doc/developer/xrefs.rst",
+      "description": "Introspection (xrefs) system — structured access to annotated entities (log messages, thread scheduling calls) in compiled binaries, GNU linker section symbols, xref extraction tools.",
+      "scope": ["lib/xref.*", "lib/zlog.*"]
+    },
+    {
+      "path": "doc/developer/building.rst",
+      "description": "Build system overview — platform-specific build guides index, configure options, dependencies, cross-compilation references.",
+      "scope": ["configure.ac", "Makefile.am", "**/subdir.am"]
+    },
+    {
+      "path": "doc/developer/cspf.rst",
+      "description": "Constrained Shortest Path First (CSPF) algorithms — supports IGP metric, TE metric, delay, and bandwidth constraints for RSVP-TE and SR Flex Algo path computation.",
+      "scope": ["lib/cspf.*", "pathd/**"]
+    },
+    {
+      "path": "doc/developer/fpm.rst",
+      "description": "Forwarding Plane Manager (FPM) module — Zebra plugin for pushing routes to external forwarding planes via Netlink or protobuf encoding over TCP stream.",
+      "scope": ["fpm/**", "zebra/zebra_fpm*"]
+    },
+    {
+      "path": "doc/developer/sbfd.rst",
+      "description": "Seamless BFD (SBFD) developer guide — RFC 7880/7881 implementation, initiator/reflector model, segment routing integration, BFD session negotiation simplification.",
+      "scope": ["bfdd/**"]
+    },
+    {
+      "path": "doc/developer/bgp-typecodes.rst",
+      "description": "BGP UPDATE attribute preprocessor constants — complete mapping of BGP_ATTR_* values to RFC-defined attributes (ORIGIN, AS_PATH, MP_REACH_NLRI, extended communities, etc.).",
+      "scope": ["bgpd/bgp_attr.*"]
+    },
+    {
+      "path": "doc/accords/cli-colors",
+      "description": "Community accord on CLI color/formatting output — colors must be used sparingly, session-level toggle (not per-command), must respect TERM/NO_COLOR env vars, pager compatibility required."
+    },
+    {
+      "path": "doc/accords/integrated-config-wins",
+      "description": "Community accord: split-configuration (zebra.conf, bgpd.conf, etc.) is deprecated. Integrated config is the future. PRs should not add new split-config-only features."
+    },
+    {
+      "path": "doc/accords/frr-service-is-watchfrr",
+      "description": "Community accord: the FRR service unit is watchfrr. Individual daemons must not be exposed as separate service units. Future: watchfrr will auto-start daemons based on config."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,201 @@
+# FRR Code Review Rules — Senior Core Maintainer Perspective
+
+You are reviewing pull requests for **FreeRangeRouting (FRR)**, one of the most widely deployed open-source routing suites in production networks worldwide. Your reviews directly impact the stability of BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD, and other critical routing daemons running on real infrastructure.
+
+**Review as if every merged line will run on production routers carrying live traffic.**
+
+---
+
+## Review Output Format
+
+Every PR review MUST follow this structure:
+
+### 1. PR Summary
+- What does this PR do? (1–3 sentences)
+- Which daemons/subsystems are affected?
+- Is this a bugfix, new feature, refactor, or documentation change?
+
+### 2. Major Concerns (ERROR)
+- Issues that **must be fixed** before merge
+- Memory safety violations, use-after-free risks, NULL dereferences
+- Routing protocol logic errors (incorrect state machine transitions, missing edge cases)
+- Concurrency bugs (missing locks, race conditions, thread-unsafe access)
+- Breaking changes to CLI, YANG models, or JSON output without deprecation path
+- Security vulnerabilities
+
+### 3. Minor Issues and Suggestions (WARNING / NOTE)
+- Code quality improvements
+- Missing documentation
+- Style violations
+- Performance suggestions
+- Opportunities to use FRR idioms
+
+### 4. Final Verdict
+- **Approve**: Code is correct, safe, and follows FRR standards
+- **Request Changes**: One or more ERROR-level issues must be addressed
+
+---
+
+## Core Review Principles
+
+### Memory Safety Is Non-Negotiable
+- Every `XMALLOC`/`XCALLOC` must have a corresponding `XFREE` on all code paths
+- Check for use-after-free, double-free, and NULL dereference
+- Verify buffer bounds on all string operations
+- Look for memory leaks in error paths and early returns
+- If a function allocates memory, verify the caller frees it (or document ownership)
+
+### Routing Protocol Correctness
+- Verify state machine transitions match the relevant RFC
+- Check that timers are properly started, reset, and cancelled
+- Verify peer/neighbor lifecycle: creation, state changes, deletion
+- Look for edge cases: rapid flap, simultaneous open, graceful restart
+- Ensure route redistribution and filtering logic is correct
+- Verify that route attributes are properly propagated and not corrupted
+
+### Concurrency and Threading
+- FRR daemons use an event-driven model with `threadmaster`
+- Verify proper use of `frr_with_mutex` for shared state
+- Check that callbacks don't block the event loop
+- Verify thread-safety of any shared data structures
+- Look for TOCTOU races in file/socket operations
+
+### CLI/VTY Consistency
+- New commands must use `DEFPY` (not `DEFUN`)
+- Command help strings must be accurate and consistent
+- Verify the `no` form of configuration commands works correctly
+- Check that `show` commands have proper JSON output (`json` keyword)
+- Ensure commands are installed in the correct VTY node
+
+### JSON Output
+- Keys must be camelCased (not kebab-case, not snake_case)
+- Empty results must return `{}`, never null or missing output
+- Structure must match or be backed by a YANG model
+- Verify JSON is valid — no trailing commas, proper escaping
+- Numeric values should be numbers, not strings
+
+### Packet Parsing & Wire Format Safety (Strict Enforcement)
+
+This is a **high-priority security concern**. Code that parses network packets or protocol messages from peers is the primary attack surface for routing daemons. Apply maximum scrutiny to any code handling wire-format data.
+
+**Mandatory checks for all packet parsing code:**
+- **Bounds checking before every read**: Verify remaining buffer length (e.g., `STREAM_READABLE(s)`, `ntohs(length)`) before extracting any field
+- **Length field validation**: Length fields read from wire data MUST be validated against remaining buffer size before use as allocation sizes or loop bounds
+- **No unsafe pointer arithmetic**: Never advance a pointer into a packet buffer without first verifying the target offset is within bounds
+- **No assumptions about minimum packet size**: Always check, even for "well-known" fixed-size headers — malformed packets are the norm in security testing
+- **Integer overflow checks**: When computing sizes from wire data (e.g., `count * element_size`), check for overflow before allocation or memcpy
+
+**Applies especially to:**
+- BGP UPDATE, OPEN, NOTIFICATION, and CAPABILITY parsing (`bgpd/bgp_packet.c`, `bgpd/bgp_attr.c`, `bgpd/bgp_open.c`)
+- OSPF LSA, Hello, and DD packet parsing (`ospfd/ospf_packet.c`, `ospfd/ospf_lsa.c`)
+- IS-IS TLV and PDU parsing (`isisd/isis_tlvs.c`, `isisd/isis_pdu.c`)
+- Zebra ZAPI message parsing (`lib/zclient.c`, `zebra/zserv.c`)
+- BFD, PIM, LDP, VRRP, and any other protocol message handlers
+- Any code using `stream_get*`, `stream_put*`, `STREAM_READABLE`, or raw buffer pointer manipulation
+
+**Flag as ERROR:**
+- Missing bounds check before `stream_getl`, `stream_getw`, `stream_getc`, or equivalent
+- Using a wire-supplied length to allocate memory without upper-bound validation
+- Pointer arithmetic on packet buffers without prior length verification
+- Missing validation of TLV/attribute length fields before processing TLV body
+
+### RCU (Read-Copy-Update) Safety
+
+Per `doc/developer/rcu.rst`:
+- `rcu_read_lock()` MUST be held **continuously** while accessing RCU-protected data — do not release and re-acquire between pointer dereference steps
+- Never call `rcu_free()` or deallocate RCU-protected memory without proper RCU grace period
+- Use `atomic_load()` / `atomic_store()` for RCU pointer access (FRR does NOT use `rcu_dereference` — that's Linux kernel API)
+- Atomic list operations require `rwlock` — read lock for all accesses (read, add, remove), write lock as sequence point before deallocation
+- `struct event` callbacks are called with RCU depth of 1 — be aware of this when writing event handlers
+
+### Assert Usage (Do NOT Misuse)
+
+Per `doc/developer/logging.rst`:
+- `assert()` is for **pretty crashes only** — development hints and invariant violations that indicate bugs
+- Asserts remain enabled in production — they WILL crash the daemon
+- **NEVER** use assert for input validation, length checking, or security constraints — use ERROR-level logging and proper error handling instead
+- For unhandled internal constraint violations (mismatched pointers, NULL required fields, data corruption), use `zlog_err` or `flog_err`, NOT assert
+
+### Edge Cases to Always Check
+- What happens when the input is NULL?
+- What happens when a list/table is empty?
+- What happens on allocation failure? (XMALLOC never returns NULL, but XREALLOC can)
+- What happens during daemon shutdown/restart?
+- What happens with maximum-size inputs? (e.g., max prefix length, max AS path)
+- What happens under rapid configuration changes?
+
+---
+
+## Style Exceptions by Directory
+
+### ldpd/
+Uses **BSD coding style**, not Linux kernel style. Do not flag BSD-style formatting.
+
+### babeld/
+Uses **K&R style braces** with **4-space indents** and function return types on their own line. Do not flag these patterns.
+
+---
+
+## Topotest Coverage (Priority Check)
+
+This is a **primary review concern**. For every PR that adds or changes daemon functionality:
+
+1. **Check if the PR includes topotest additions/updates** under `tests/topotests/`
+2. **Cross-reference the changed code paths against existing topotests** — examine whether the specific daemon behavior being modified is exercised by any test topology
+3. **Evaluate coverage depth** — a test that merely starts the daemon is insufficient; tests must exercise the specific code paths being changed (e.g., if a PR changes BGP route-map handling, check that the topotest actually applies route-maps and validates the filtered output)
+4. If significant new logic is introduced with no test coverage, flag it clearly
+
+**When to flag:**
+- New features without any topotest
+- Behavior changes without updated test assertions
+- Bug fixes for complex logic without a regression test
+- PR modifies protocol state machine but no test validates the state transitions
+
+**When NOT to flag (avoid spam):**
+- Simple one-line bug fixes (e.g., off-by-one, NULL check)
+- Typo or comment corrections
+- Documentation-only changes
+- Pure refactors that don't change behavior (existing tests should still pass)
+
+**Topotest quality checks (if tests ARE included):**
+- Tests must use `pytest` framework (see `doc/developer/topotests.rst`)
+- Python test code must be formatted with `black`
+- Tests should validate specific outputs, not just "daemon didn't crash"
+- JSON output tests should use `json_cmp` for structured comparison
+
+## Documentation Checks (Smart, Non-Intrusive)
+
+Documentation flags must be **context-aware**. Spamming every PR with "update the docs" is counterproductive.
+
+### User Docs (doc/user/)
+Ask "Have the User Docs been updated?" **only when**:
+- New CLI commands are added (DEFPY/DEFUN)
+- Existing CLI command syntax changes
+- New `show` commands or JSON output fields are added
+- YANG model changes that affect user configuration
+- New daemon behavior that users need to know about
+
+### Developer Docs (doc/developer/)
+Ask "Have the Developer Docs been updated?" **only when**:
+- New internal APIs are added to `lib/`
+- Architectural changes to data structures or threading model
+- New locking patterns or event loop conventions
+- Changes to the build system or development workflow
+
+### NEVER ask for doc updates on:
+- Standard, simple bug fixes
+- Minor refactors that follow existing patterns
+- Internal variable renames or code cleanup
+- Changes that don't alter any user-visible or developer-visible behavior
+
+---
+
+## What Makes a Good FRR Patch
+
+1. **Does one thing well** — single logical change per commit
+2. **Explains why** — commit message describes the problem and solution
+3. **Is tested** — includes or references automated tests for significant changes
+4. **Is safe** — no memory leaks, no crashes, no undefined behavior
+5. **Is backwards compatible** — or has a proper deprecation path
+6. **Is documented** — user-facing changes have doc/user/ updates
+7. **Passes CI** — all checks green, no new static analysis warnings

--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -27,21 +27,21 @@ Static Route Commands
 Static routing is a very fundamental feature of routing technology. It defines
 a static prefix and gateway, with several possible forms.
 
-.. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [tag TAG] [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [tag TAG] [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
    NETWORK is destination prefix with a valid v4 or v6 network based upon
    initial form of the command.
@@ -61,6 +61,16 @@ a static prefix and gateway, with several possible forms.
    Alternatively, the gateway can be specified as ``Null0`` or ``blackhole`` to create a blackhole
    route that drops all traffic. It can also be specified as ``reject`` to create an unreachable
    route that rejects traffic with ICMP "Destination Unreachable" messages.
+
+   TAG is an optional 32-bit unsigned integer (1–4294967295) that marks the
+   route entry in the RIB. See :ref:`static-route-tag` for details and
+   limitations.
+
+   DISTANCE is an optional administrative distance (1–255; default 1). See
+   :ref:`static-route-distance-metric` for details.
+
+   METRIC is an optional route metric (0–4294967295; default 0). See
+   :ref:`static-route-distance-metric` for details.
 
    WEIGHT is an optional parameter that specifies the weight attributed to a
    nexthop when multiple nexthops are configured for the same static route. The
@@ -164,6 +174,126 @@ but this time, the route command will apply to the VRF.
    vrf r1-cust1
     ip route 10.0.0.0/24 10.0.0.2
    exit-vrf
+
+
+.. _static-route-distance-metric:
+
+Administrative Distance and Metric
+===================================
+
+Static routes are grouped internally by ``(table-id, distance, metric)``.
+Nexthops that share the same tuple belong to the same *path group* and are
+installed in the RIB together as an ECMP set.  Nexthops in different path
+groups under the same prefix are independent: only the best-preference group
+is active in the RIB at any time.
+
+**ECMP** — Multiple nexthops at the same ``(distance, metric)`` form an
+equal-cost multipath group and are active in the RIB together:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2
+   ip route 10.0.0.0/8 10.0.0.3
+
+Both nexthops share ``(distance=1, metric=0)`` and are active in the RIB as ECMP.
+
+**Floating static by distance** — Nexthops at different distances form
+separate path groups.  The lowest-distance group is active; others are held
+in reserve and promoted when the active group becomes unreachable:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2
+   ip route 10.0.0.0/8 10.0.0.3 200
+
+``10.0.0.2`` is the primary (distance 1); ``10.0.0.3`` is the fallback
+(distance 200), promoted only when ``10.0.0.2`` is gone.
+
+**Floating static by metric** — Within the same distance, nexthops at
+different metrics also form separate path groups.  The lower-metric group is
+active:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 metric 100
+   ip route 10.0.0.0/8 10.0.0.3 metric 200
+
+``10.0.0.2`` is the primary (metric 100); ``10.0.0.3`` is the fallback
+(metric 200), promoted only when ``10.0.0.2`` is gone.
+
+**Nexthop uniqueness and automatic move** — A given nexthop (identified by
+its forwarding information: type, gateway address, and interface) may appear
+in at most one path group under a prefix at a time.  If a nexthop is
+reconfigured with a new distance or metric, FRR automatically removes it from
+the old path group and installs it in the new one:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 10
+   ! Reconfigure with a new distance — old entry is removed automatically:
+   ip route 10.0.0.0/8 10.0.0.2 20
+
+After the second command there is exactly one path group for ``10.0.0.2`` at
+distance 20; no stale distance-10 entry remains.  The same applies when
+metric is changed.
+
+**Removing routes without distance or metric** — When distance or metric is
+not specified on a ``no ip route`` command, FRR searches all path groups under
+the prefix for a matching nexthop and removes whichever it finds:
+
+.. code-block:: frr
+
+   no ip route 10.0.0.0/8 10.0.0.2
+
+This removes ``10.0.0.2`` regardless of which distance or metric it was
+configured with.  When distance and metric are specified, only that exact path
+group is targeted.
+
+
+.. _static-route-tag:
+
+Route Tag
+=========
+
+TAG is a 32-bit unsigned integer (1–4294967295) that marks a route entry in
+the RIB.  It can be matched by routing policy (route-maps, prefix-lists) to
+filter or modify routes based on their tag value.
+
+The tag is a per-path-group attribute: it is shared by all nexthops in a path
+group and carried into the RIB.  Unlike distance and metric, tag is **not**
+part of the path group identity — two nexthops at the same ``(distance,
+metric)`` always belong to the same path group regardless of their configured
+tags.
+
+**Per-path-group tag** — Assigning a distinct tag to each path group lets
+routing policy distinguish primary from backup routes:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 tag 100 10
+   ip route 10.0.0.0/8 10.0.0.3 tag 200 20
+
+``10.0.0.2`` (distance 10) carries tag 100 and ``10.0.0.3`` (distance 20)
+carries tag 200.  Both tags are visible in the RIB simultaneously.
+
+.. note::
+
+   **Limitation — same (distance, metric), different tag:** because tag is
+   not part of the path group key, two nexthops at the same ``(distance,
+   metric)`` belong to the same path group regardless of their tags.  When
+   different tags are configured for nexthops in the same path group, the
+   last-configured value applies to the entire group and the earlier value is
+   silently overwritten:
+
+   .. code-block:: frr
+
+      ip route 10.0.0.0/8 10.0.0.2 tag 100 10
+      ip route 10.0.0.0/8 10.0.0.3 tag 200 10
+
+   Both nexthops are grouped at distance 10 and the path tag becomes 200
+   (the last value configured).  ``show running-config`` reflects only the
+   final value.  To assign independent tags to nexthops, use different
+   distances or metrics.
 
 
 SR-TE Route Commands

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -145,7 +145,7 @@ int routing_control_plane_protocols_name_validate(
 	"/frr-routing:routing/control-plane-protocols/"                                            \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                  \
 	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"             \
-	"path-list[table-id='%u'][distance='%u']"
+	"path-list[table-id='%u'][distance='%u'][metric='%u']"
 
 #define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                                                \
 	"/frr-routing:routing/control-plane-protocols/"                                            \

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -32,6 +32,7 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	const char *vrf;
 	uint8_t distance;
 	uint32_t table_id;
+	uint32_t metric;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -61,7 +62,8 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		distance = yang_dnode_get_uint8(args->dnode, "distance");
 		table_id = yang_dnode_get_uint32(args->dnode, "table-id");
-		pn = static_add_path(rn, table_id, distance);
+		metric = yang_dnode_get_uint32(args->dnode, "metric");
+		pn = static_add_path(rn, table_id, distance, metric);
 		nb_running_set_entry(args->dnode, pn);
 	}
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -141,8 +141,8 @@ bool static_add_nexthop_validate(const char *nh_vrf_name,
 	return true;
 }
 
-struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
-				    uint8_t distance)
+struct static_path *static_add_path(struct route_node *rn, uint32_t table_id, uint8_t distance,
+				    uint32_t metric)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
@@ -154,6 +154,7 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 
 	pn->rn = rn;
 	pn->distance = distance;
+	pn->metric = metric;
 	pn->table_id = table_id;
 	static_nexthop_list_init(&(pn->nexthop_list));
 

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -77,6 +77,49 @@ enum static_install_states {
 PREDECL_DLIST(static_path_list);
 PREDECL_DLIST(static_nexthop_list);
 
+/*
+ * Data model: prefix -> path-list -> nexthop-list
+ *
+ * Each prefix (route_node) has one static_route_info attached as rn->info.
+ * Under it is a list of static_path objects, each uniquely identified by
+ * (table-id, distance, metric).  Under each path is a list of static_nexthop
+ * objects that share those attributes.  Tag is a per-path attribute (not a key).
+ *
+ *   prefix (route_node / static_route_info)
+ *     |
+ *     +-- static_path  [table-id=0, distance=10, metric=0]  tag=100
+ *     |     +-- static_nexthop  NH1   \
+ *     |     +-- static_nexthop  NH2   /  ECMP group (same distance, metric)
+ *     |
+ *     +-- static_path  [table-id=0, distance=10, metric=20]  tag=200
+ *     |     +-- static_nexthop  NH3       metric-based floating static
+ *     |
+ *     +-- static_path  [table-id=0, distance=20, metric=0]  tag=300
+ *           +-- static_nexthop  NH4       AD-based floating static (standby)
+ *
+ * Administrative distance (AD): controls route preference.  Paths with a
+ * lower AD are preferred; a higher-AD path is installed in zebra only when
+ * all lower-AD nexthops become unreachable (floating static / backup route).
+ *
+ * Metric: a 32-bit value that refines route preference within the same AD.
+ * Zebra treats two static routes with the same (type, distance) but different
+ * metrics as distinct route_entries; rib_choose_best() selects the lower-metric
+ * entry.  This enables metric-based floating routes within the same AD.
+ * The default metric is 0.
+ *
+ * Tag: a 32-bit marker attached to a path and carried into the RIB.  Tag is
+ * shared by all nexthops in a path and is not part of the path identity.
+ * Nexthops at the same (distance, metric) always share one static_path
+ * regardless of their configured tag values; the last-configured tag applies
+ * to the whole group.  To assign independent tags, use different distances
+ * or metrics.
+ *
+ * ECMP: multiple static_nexthop entries under the same static_path are
+ * installed together as an equal-cost multipath group.  The weight field
+ * on each nexthop lets operators bias the traffic distribution within the
+ * group.
+ */
+
 /* Static route information */
 struct static_route_info {
 	struct static_vrf *svrf;
@@ -93,6 +136,8 @@ struct static_path {
 	struct static_path_list_item list;
 	/* Administrative distance. */
 	uint8_t distance;
+	/* Metric */
+	uint32_t metric;
 	/* Tag */
 	route_tag_t tag;
 	/* Table-id */
@@ -225,8 +270,8 @@ extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 					   struct static_vrf *svrf);
 extern void static_del_route(struct route_node *rn);
 
-extern struct static_path *static_add_path(struct route_node *rn,
-					   uint32_t table_id, uint8_t distance);
+extern struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
+					   uint8_t distance, uint32_t metric);
 extern void static_del_path(struct static_path *pn);
 
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -55,6 +55,7 @@ struct static_route_args {
 	const char *flag;
 	const char *tag;
 	const char *distance;
+	const char *metric;
 	const char *label;
 	const char *table;
 	const char *color;
@@ -115,6 +116,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	const char *buf_gate_str;
 	struct ipaddr gate_ip;
 	uint8_t distance = ZEBRA_STATIC_DISTANCE_DEFAULT;
+	uint32_t metric = 0;
 	route_tag_t tag = 0;
 	uint32_t table_id = 0;
 	const struct lyd_node *dnode;
@@ -216,6 +218,10 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	if (args->distance)
 		distance = strtol(args->distance, NULL, 10);
 
+	/* Metric */
+	if (args->metric)
+		metric = strtoul(args->metric, NULL, 10);
+
 	/* tag */
 	if (args->tag)
 		tag = strtoul(args->tag, NULL, 10);
@@ -233,7 +239,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 
 		/*
 		 * If there's already the same nexthop but with a different
-		 * distance, then remove it for the replacement.
+		 * distance or metric, then remove it for the replacement.
 		 */
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (dnode) {
@@ -248,7 +254,8 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		/* route + path processing */
 		snprintf(xpath_prefix, sizeof(xpath_prefix), FRR_STATIC_ROUTE_INFO_KEY_XPATH,
 			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
-			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance);
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance,
+			 metric);
 
 		nb_cli_enqueue_change(vty, xpath_prefix, NB_OP_CREATE, NULL);
 
@@ -461,8 +468,8 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 			snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_XPATH,
 				 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix,
 				 buf_src_prefix, yang_afi_safi_value2identity(args->afi, args->safi),
-				 table_id, distance, buf_nh_type, args->nexthop_vrf, buf_gate_str,
-				 args->interface_name);
+				 table_id, distance, metric, buf_nh_type, args->nexthop_vrf,
+				 buf_gate_str, args->interface_name);
 		else
 			snprintf(ab_xpath, sizeof(ab_xpath),
 				 FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH, "frr-staticd:staticd",
@@ -519,6 +526,7 @@ DEFPY_YANG (ip_mroute_dist,
        ip_mroute_dist_cmd,
        "[no] ip mroute A.B.C.D/M$prefix <A.B.C.D$gate|INTERFACE$ifname> [{"
        "(1-255)$distance"
+       "|metric (0-4294967295)"
        "|bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}]"
        "}]",
        NO_STR
@@ -528,6 +536,8 @@ DEFPY_YANG (ip_mroute_dist,
        "Nexthop address\n"
        "Nexthop interface name\n"
        "Distance\n"
+       "Set metric for this route\n"
+       "Metric value\n"
        BFD_INTEGRATION_STR
        BFD_INTEGRATION_MULTI_HOP_STR
        BFD_INTEGRATION_SOURCE_STR
@@ -543,6 +553,7 @@ DEFPY_YANG (ip_mroute_dist,
 		.gateway = gate_str,
 		.interface_name = ifname,
 		.distance = distance_str,
+		.metric = metric_str,
 		.bfd = !!bfd,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
@@ -561,6 +572,7 @@ DEFPY_YANG(ip_route_blackhole,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+	  |metric (0-4294967295)                                              \
 	  |vrf NAME                                                           \
 	  |label WORD                                                         \
           |table (1-4294967295)                                               \
@@ -575,6 +587,8 @@ DEFPY_YANG(ip_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -589,6 +603,7 @@ DEFPY_YANG(ip_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -605,6 +620,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+	  |metric (0-4294967295)                                              \
 	  |label WORD                                                         \
 	  |table (1-4294967295)                                               \
           }]",
@@ -618,6 +634,8 @@ DEFPY_YANG(ip_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -631,6 +649,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -655,6 +674,7 @@ DEFPY_YANG(ip_route_address_interface,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |vrf NAME                                    \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
@@ -677,6 +697,8 @@ DEFPY_YANG(ip_route_address_interface,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -709,6 +731,7 @@ DEFPY_YANG(ip_route_address_interface,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -736,6 +759,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
 	  |nexthop-vrf NAME                            \
@@ -757,6 +781,8 @@ DEFPY_YANG(ip_route_address_interface_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -788,6 +814,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -814,6 +841,7 @@ DEFPY_YANG(ip_route,
 	[{                                             	   \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |vrf NAME                                        \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
@@ -835,6 +863,8 @@ DEFPY_YANG(ip_route,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -866,6 +896,7 @@ DEFPY_YANG(ip_route,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -891,6 +922,7 @@ DEFPY_YANG(ip_route_vrf,
 	[{                                                 \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
 	  |nexthop-vrf NAME                                \
@@ -911,6 +943,8 @@ DEFPY_YANG(ip_route_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -941,6 +975,7 @@ DEFPY_YANG(ip_route_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -965,6 +1000,7 @@ DEFPY_YANG(ipv6_route_blackhole,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
             |table (1-4294967295)                          \
@@ -980,6 +1016,8 @@ DEFPY_YANG(ipv6_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -994,6 +1032,7 @@ DEFPY_YANG(ipv6_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -1009,6 +1048,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
             |table (1-4294967295)                          \
           }]",
@@ -1023,6 +1063,8 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -1036,6 +1078,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -1058,6 +1101,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1078,7 +1122,10 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1104,6 +1151,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1130,6 +1178,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1149,7 +1198,10 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1175,6 +1227,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1199,6 +1252,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1218,7 +1272,10 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1243,6 +1300,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1267,6 +1325,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1285,7 +1344,10 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1310,6 +1372,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1617,6 +1680,7 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	enum static_blackhole_type bh_type;
 	uint32_t tag;
 	uint8_t distance;
+	uint32_t metric;
 	struct mpls_label_iter iter;
 	struct srv6_seg_iter seg_iter;
 	enum srv6_headend_behavior srv6_encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
@@ -1692,6 +1756,10 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	distance = yang_dnode_get_uint8(path, "distance");
 	if (distance != ZEBRA_STATIC_DISTANCE_DEFAULT || show_defaults)
 		vty_out(vty, " %" PRIu8, distance);
+
+	metric = yang_dnode_get_uint32(path, "metric");
+	if (metric != 0 || show_defaults)
+		vty_out(vty, " metric %" PRIu32, metric);
 
 	iter.vty = vty;
 	iter.first = true;
@@ -1863,6 +1931,7 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 {
 	uint32_t table_id1, table_id2;
 	uint8_t distance1, distance2;
+	uint32_t metric1, metric2;
 
 	table_id1 = yang_dnode_get_uint32(dnode1, "table-id");
 	table_id2 = yang_dnode_get_uint32(dnode2, "table-id");
@@ -1873,7 +1942,13 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 	distance1 = yang_dnode_get_uint8(dnode1, "distance");
 	distance2 = yang_dnode_get_uint8(dnode2, "distance");
 
-	return (int)distance1 - (int)distance2;
+	if (distance1 != distance2)
+		return (int)distance1 - (int)distance2;
+
+	metric1 = yang_dnode_get_uint32(dnode1, "metric");
+	metric2 = yang_dnode_get_uint32(dnode2, "metric");
+
+	return numcmp(metric1, metric2);
 }
 
 static void static_segment_routing_cli_show(struct vty *vty, const struct lyd_node *dnode,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -441,6 +441,8 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);
 		api.distance = pn->distance;
 	}
+	SET_FLAG(api.message, ZAPI_MESSAGE_METRIC);
+	api.metric = pn->metric;
 	if (pn->tag) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_TAG);
 		api.tag = pn->tag;

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -180,7 +180,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -193,7 +193,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -250,7 +250,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -263,7 +263,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
                 "mgmt commit apply",
             ]
         }
@@ -303,7 +303,7 @@ def test_mgmt_commit_abort(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit abort",
             ]
         }
@@ -355,7 +355,7 @@ def test_mgmt_delete_config(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -662,7 +662,7 @@ def test_mgmt_chaos_stop_start_frr(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -738,7 +738,7 @@ def test_mgmt_chaos_kill_daemon(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }

--- a/tests/topotests/static_route_distance/r1/frr.conf
+++ b/tests/topotests/static_route_distance/r1/frr.conf
@@ -1,0 +1,11 @@
+interface r1-eth0
+  ip address 192.0.2.1/24
+  ipv6 address 2001:db8:0:1::1/64
+
+interface r1-eth1
+  ip address 198.51.100.1/24
+  ipv6 address 2001:db8:0:2::1/64
+
+interface r1-eth2
+  ip address 203.0.113.1/24
+  ipv6 address 2001:db8:0:3::1/64

--- a/tests/topotests/static_route_distance/test_static_route_distance.py
+++ b/tests/topotests/static_route_distance/test_static_route_distance.py
@@ -1,0 +1,759 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path administrative distance for static routes.
+
+Design: administrative distance and tag live in static_path, which is keyed
+by (table-id, distance).  Tag is a modifiable leaf shared by all nexthops in
+a path.  Different distances produce separate path objects, enabling floating
+static routes (primary/backup) under a single prefix.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. AD replacement: reconfiguring the same nexthop with a new AD must
+     update the existing RIB entry in place (NB_OP_MODIFY) and remove the
+     stale old-distance zebra entry — not create a duplicate.
+
+  2. Floating static route: two nexthops at different ADs under the same
+     prefix; the lower-AD nexthop is active in the FIB and the higher-AD
+     standby is promoted when the primary is removed.
+
+  3. ECMP: two nexthops at the same AD are both active in the FIB.
+     Removing one ECMP member leaves the other active at the same AD.
+
+  4. ECMP with floating standby: primary ECMP group (NH1+NH2, AD 10) plus
+     a standby (NH3, AD 20).  Removing primaries one by one shrinks the
+     active group; the standby is promoted only when the last primary is
+     removed.
+
+  5. ECMP AD change (promote/demote): a nexthop moves in and out of the
+     ECMP group by having its AD changed — covering both promotion
+     (standby joins the ECMP group) and demotion (ECMP member becomes
+     standby), and re-promotion back into the group.
+
+  6. Delete standby only: deleting the standby nexthop must leave the
+     primary completely unaffected; the standby RIB entry is fully
+     withdrawn from zebra.
+
+  7. Delete primary then standby: deleting the primary promotes the
+     standby; deleting the standby fully withdraws the route from both
+     RIB and FIB.
+
+  8. Delete without distance: 'no ip route X/M via Y' without a distance
+     argument must find and remove the route regardless of configured AD.
+     With the old code (distance in path-list key), omitting distance
+     defaulted to AD=1 and the delete would silently fail to match a
+     route installed at a different AD.
+"""
+#
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+# Three nexthop addresses reachable via r1-eth0, eth1, eth2 respectively.
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _route_distances(router, prefix, ipv6=False):
+    """Return the set of administrative distances present in the RIB for prefix."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    if prefix not in json_data:
+        return set()
+    return {entry["distance"] for entry in json_data[prefix]}
+
+
+def _route_nexthops(router, prefix, ipv6=False):
+    """Return the set of nexthop IPs from the selected (best-path) route entry.
+
+    The nexthop-level 'fib' flag in the JSON output indicates whether the nexthop group is installed
+    in the kernel nexhop table — it can be true even for non-selected routes that
+    share a nexhop group.  The route-level 'selected' flag is the correct
+    indicator of which entry is the active best path.
+    """
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    if prefix not in json_data:
+        return set()
+    active = set()
+    for entry in json_data[prefix]:
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("active"):
+                active.add(nh.get("ip", nh.get("interfaceName", "")))
+    return active
+
+
+def _check_distances(router, prefix, expected, ipv6=False):
+    """Return None when RIB distances equal expected, else return the actual set."""
+    actual = _route_distances(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_route(router, prefix, expected, ipv6=False):
+    """Return None when active route nexthops equal expected, else return the actual set."""
+    actual = _route_nexthops(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_distances(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_distances, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_route(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_route, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return the list of static-route lines for prefix in 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    """Return None when running-config lines match expected_lines (as a set), else actual."""
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    expected = set(expected_lines)
+    return None if actual == expected else actual
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(
+        _check_running, router, prefix, expected_lines, ipv6
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test: AD replacement
+# ---------------------------------------------------------------------------
+
+def run_ad_replacement(ipv6=False):
+    """
+    Same nexthop reconfigured with a new AD must replace the old RIB entry
+    and leave running-config with exactly one entry at the new AD.
+
+    Steps:
+      1. Install route via NH1 at AD 10.
+      2. Reconfigure the same route via NH1 at AD 20.
+      3. Verify only AD 20 is present in RIB; AD 10 entry is gone.
+      4. Verify running-config shows exactly 'ip route ... NH1 20', not the old '... 10'.
+      5. Clean up; verify running-config is empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"AD replacement [1]: expected {{10}}, got {result}"
+
+    # Step 2: same nexthop, new AD — must replace, not duplicate
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_distances(r1, prefix, {20}, ipv6)
+    assert result is None, (
+        f"AD replacement [2]: stale AD 10 present or AD 20 missing; got {result}"
+    )
+
+    # Step 3: running-config must show exactly one entry at AD 20, not AD 10
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"AD replacement [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"AD replacement [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"AD replacement [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ad_replacement_ipv4():
+    "Same IPv4 nexthop reconfigured with new AD replaces old RIB entry."
+    run_ad_replacement(ipv6=False)
+
+
+def test_ad_replacement_ipv6():
+    "Same IPv6 nexthop reconfigured with new AD replaces old RIB entry."
+    run_ad_replacement(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: floating static route (two different nexthops, different ADs)
+# ---------------------------------------------------------------------------
+
+def run_floating_static(ipv6=False):
+    """
+    Two nexthops under the same prefix with independent ADs.
+
+    Steps:
+      1. Install primary NH1 at AD 10 and standby NH2 at AD 20.
+      2. Verify NH1 is active in FIB (lower AD wins).
+      3. Remove NH1; verify NH2 is promoted to active.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Floating static [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: lower-AD nexthop active
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, f"Floating static [2]: expected {nh1} active, got {result}"
+
+    # Step 3: remove primary → standby promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Floating static [3]: expected {nh2} active after primary removed, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"Floating static [cleanup]: route not removed; got {result}"
+
+
+def test_floating_static_ipv4():
+    "IPv4 floating static: lower-AD nexthop active, standby promoted on primary removal."
+    run_floating_static(ipv6=False)
+
+
+def test_floating_static_ipv6():
+    "IPv6 floating static: lower-AD nexthop active, standby promoted on primary removal."
+    run_floating_static(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP (multiple nexthops at the same AD)
+# ---------------------------------------------------------------------------
+
+def run_ecmp(ipv6=False):
+    """
+    Two nexthops at the same AD are both active in the FIB (ECMP).
+    Removing one ECMP member leaves the remaining one active.
+
+    Steps:
+      1. Install NH1 and NH2 both at AD 10.
+      2. Verify both are active in FIB.
+      3. Remove NH1; verify NH2 remains active at AD 10.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"ECMP [1]: expected single AD {{10}}, got {result}"
+
+    # Step 2: both nexthops active (ECMP)
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, f"ECMP [2]: expected both {nh1},{nh2} active, got {result}"
+
+    # Step 3: remove one ECMP member
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP [3]: expected only {nh2} active after {nh1} removed, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"ECMP [3]: AD should still be {{10}}, got {result}"
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_ipv4():
+    "IPv4 ECMP: two nexthops at same AD both active; removing one leaves the other."
+    run_ecmp(ipv6=False)
+
+
+def test_ecmp_ipv6():
+    "IPv6 ECMP: two nexthops at same AD both active; removing one leaves the other."
+    run_ecmp(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP with floating standby
+# ---------------------------------------------------------------------------
+
+def run_ecmp_with_standby(ipv6=False):
+    """
+    ECMP primary group (NH1+NH2 at AD 10) plus a floating standby (NH3 at AD 20).
+
+    Steps:
+      1. Install NH1, NH2 at AD 10 and NH3 at AD 20.
+      2. Verify NH1 and NH2 are active (ECMP); NH3 is in RIB but not FIB.
+      3. Remove NH1; verify NH2 is the sole active nexhop at AD 10.
+         NH3 remains standby (still not in FIB).
+      4. Remove NH2 (last primary); verify NH3 is promoted to active.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: ECMP primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+        f"ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"ECMP+standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: NH1+NH2 active (ECMP), NH3 standby (not in FIB)
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [2]: expected {nh1},{nh2} active (ECMP), got {result}"
+    )
+
+    # Step 3: remove NH1 — NH2 sole primary, NH3 still standby
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected only {nh2} active, NH3 still standby, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected {{10,20}} in RIB, got {result}"
+    )
+
+    # Step 4: remove last primary NH2 — standby NH3 promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_route(r1, prefix, {nh3}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [4]: expected {nh3} promoted after all primaries removed, got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh3} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP+standby [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_with_standby_ipv4():
+    "IPv4 ECMP primary group with floating standby; standby promoted when all primaries removed."
+    run_ecmp_with_standby(ipv6=False)
+
+
+def test_ecmp_with_standby_ipv6():
+    "IPv6 ECMP primary group with floating standby; standby promoted when all primaries removed."
+    run_ecmp_with_standby(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: promote/demote nexthops by changing AD
+# ---------------------------------------------------------------------------
+
+def run_ecmp_ad_change(ipv6=False):
+    """
+    A nexthop moves in and out of the ECMP group by having its AD changed.
+
+    Steps:
+      1. NH1 at AD 10 (sole primary), NH2 at AD 20 (standby).
+         Verify NH1 active, NH2 not in FIB.
+      2. Change NH2 AD 20 → 10: NH2 joins the ECMP group.
+         Verify both NH1 and NH2 active; only AD 10 in RIB (AD 20 gone).
+      3. Change NH1 AD 10 → 20: NH1 leaves the ECMP group and becomes standby.
+         Verify NH2 sole primary at AD 10; NH1 standby at AD 20.
+      4. Change NH1 AD 20 → 10: NH1 rejoins the ECMP group.
+         Verify both NH1 and NH2 active again at AD 10.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 primary at AD 10, NH2 standby at AD 20
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, f"ECMP AD change [1]: expected only {nh1} active, got {result}"
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"ECMP AD change [1]: expected {{10,20}} in RIB, got {result}"
+
+    # Step 2: promote NH2 into ECMP group (AD 20 → 10)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [2]: expected both {nh1},{nh2} active after NH2 promoted, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [2]: stale AD 20 still present after NH2 promoted, got {result}"
+    )
+    # running-config: both nexthops at AD 10, no stale AD 20 entry
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} 10",
+         f"ip{ip_ver} route {prefix} {nh2} 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [2]: running-config mismatch after NH2 promoted; got {result}"
+    )
+
+    # Step 3: demote NH1 to standby (AD 10 → 20)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [3]: expected only {nh2} active after NH1 demoted, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [3]: expected {{10,20}} in RIB after NH1 demoted, got {result}"
+    )
+    # running-config: NH2 at AD 10 (primary), NH1 at AD 20 (standby), no duplicate
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh2} 10",
+         f"ip{ip_ver} route {prefix} {nh1} 20"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [3]: running-config mismatch after NH1 demoted; got {result}"
+    )
+
+    # Step 4: NH1 rejoins ECMP group (AD 20 → 10)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [4]: expected both {nh1},{nh2} active after NH1 rejoined, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [4]: stale AD 20 still present after NH1 rejoined, got {result}"
+    )
+    # running-config: both nexthops at AD 10, no stale AD 20 entry
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} 10",
+         f"ip{ip_ver} route {prefix} {nh2} 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [4]: running-config mismatch after NH1 rejoined; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP AD change [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"ECMP AD change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ecmp_ad_change_ipv4():
+    "IPv4: nexthop moves in and out of ECMP group by changing its AD."
+    run_ecmp_ad_change(ipv6=False)
+
+
+def test_ecmp_ad_change_ipv6():
+    "IPv6: nexthop moves in and out of ECMP group by changing its AD."
+    run_ecmp_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: targeted deletion scenarios
+# ---------------------------------------------------------------------------
+
+def run_delete_standby(ipv6=False):
+    """
+    Deleting the standby nexhop must not affect the active primary.
+
+    Steps:
+      1. NH1 at AD 10 (primary), NH2 at AD 20 (standby).
+      2. Delete NH2 (standby only).
+      3. Verify NH1 still active; AD 20 entry completely gone from RIB.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Delete standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: delete standby only
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+
+    # Step 3: primary unaffected; standby RIB entry completely withdrawn
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"Delete standby [3]: expected only {{10}} in RIB after standby deleted, got {result}"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Delete standby [3]: primary {nh1} should still be active, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"Delete standby [cleanup]: route not fully removed, got {result}"
+
+
+def run_delete_primary_then_standby(ipv6=False):
+    """
+    Delete primary first (standby takes over), then delete standby; route must
+    be completely withdrawn from RIB and FIB after the last nexhop is removed.
+
+    Steps:
+      1. NH1 at AD 10 (primary), NH2 at AD 20 (standby).
+      2. Delete NH1; verify NH2 promoted and AD 10 entry gone.
+      3. Delete NH2; verify route is completely gone from RIB and FIB.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Delete primary+standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: delete primary — standby promoted, AD 10 entry gone
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, {20}, ipv6)
+    assert result is None, (
+        f"Delete primary+standby [2]: expected only {{20}} after primary deleted, got {result}"
+    )
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Delete primary+standby [2]: expected {nh2} promoted to active, got {result}"
+    )
+
+    # Step 3: delete standby — route fully withdrawn
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete primary+standby [3]: route should be fully gone, got {result}"
+    )
+    result = _expect_route(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete primary+standby [3]: FIB entry should be gone, got {result}"
+    )
+
+
+def test_delete_standby_ipv4():
+    "IPv4: deleting the standby nexhop leaves the primary completely unaffected."
+    run_delete_standby(ipv6=False)
+
+
+def test_delete_standby_ipv6():
+    "IPv6: deleting the standby nexhop leaves the primary completely unaffected."
+    run_delete_standby(ipv6=True)
+
+
+def test_delete_primary_then_standby_ipv4():
+    "IPv4: delete primary (standby promoted), then delete standby (route fully withdrawn)."
+    run_delete_primary_then_standby(ipv6=False)
+
+
+def test_delete_primary_then_standby_ipv6():
+    "IPv6: delete primary (standby promoted), then delete standby (route fully withdrawn)."
+    run_delete_primary_then_standby(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: deletion without specifying distance
+# ---------------------------------------------------------------------------
+
+def run_delete_without_distance(ipv6=False):
+    """
+    Distance is no longer part of the nexhop key, so 'no ip route X/M via Y'
+    without a distance value must find and remove the route regardless of what
+    AD was configured.  With the old code (distance in path-list key), omitting
+    distance defaulted to AD=1 and the delete would fail to match a route
+    installed at a different AD.
+
+    Steps:
+      1. Install route via NH1 at non-default AD 50.
+      2. Delete using 'no ip route X/M via NH1' with no distance specified.
+      3. Verify route is completely gone.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at non-default AD 50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 50\n")
+    result = _expect_distances(r1, prefix, {50}, ipv6)
+    assert result is None, f"Delete without distance [1]: expected {{50}}, got {result}"
+
+    # Step 2: delete without specifying distance
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+
+    # Step 3: route must be gone from RIB and running-config
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete without distance [3]: route at AD 50 not removed by 'no' without distance; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Delete without distance [3]: stale running-config entry after delete; got {result}"
+    )
+
+
+def test_delete_without_distance_ipv4():
+    "IPv4: 'no ip route X/M via Y' without distance removes the route regardless of configured AD."
+    run_delete_without_distance(ipv6=False)
+
+
+def test_delete_without_distance_ipv6():
+    "IPv6: 'no ip route X/M via Y' without distance removes the route regardless of configured AD."
+    run_delete_without_distance(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/static_route_distance/test_static_route_metric.py
+++ b/tests/topotests/static_route_distance/test_static_route_metric.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path metric for static routes.
+
+Design: metric is a YANG path-list key alongside table-id and distance.
+Nexthops sharing the same (table-id, distance, metric) tuple form one ECMP
+group.  Zebra keeps separate route_entry objects for routes with the same
+(type, instance, distance) but different metrics because rib_compare_routes()
+treats static routes with different metrics as non-equal, and the
+process_subq_early_route_delete() loop skips entries whose metric does not
+match the delete request.  Zebra selects the lower-metric entry as best —
+enabling metric-based floating routes within the same administrative distance.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. Metric replacement: reconfiguring the same nexthop with a new metric
+     must update the existing RIB entry (including the active metric value
+     reported by zebra) and remove the stale old-metric entry — not
+     duplicate it.
+
+  2. ECMP at same (distance, metric): two nexthops with matching distance
+     and metric are both active in the FIB.  Removing one leaves the other
+     active at the same (distance, metric).
+
+  3. Metric-based floating within same distance: NH1@(AD=10, metric=100)
+     and NH2@(AD=10, metric=200) are kept as separate RIB entries; the lower
+     metric wins in zebra.  Removing NH1 promotes NH2.
+
+  4. Metric change (promote/demote): a nexthop moves in and out of the
+     ECMP group by having its metric changed — covering both promotion
+     (standby joins ECMP group) and demotion (ECMP member becomes standby),
+     and re-promotion back into the group.
+
+  5. Metric-aware deletion: 'no ip route X/M via Y DIST metric M' finds
+     the exact entry; 'no ip route X/M via Y DIST' without metric defaults
+     to metric=0 and will NOT match a route installed at a non-zero metric;
+     'no ip route X/M via Y' without any key does a lazy search that finds
+     the route regardless of distance and metric.  A two-metric scenario
+     verifies that zebra's delete-lookup loop removes only the matching
+     metric entry, leaving the other intact.
+
+  6. Running-config format: metric appears after distance in the
+     'show running-config' output; distance=default is omitted; metric=0
+     is omitted.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_keys(router, prefix, ipv6=False):
+    """Return set of (distance, metric) tuples present in the RIB for prefix."""
+    return {
+        (e.get("distance", 0), e.get("metric", 0))
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _active_nexthops(router, prefix, ipv6=False):
+    """Return set of nexthop IPs from the selected (best-path) route entry."""
+    active = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("active"):
+                active.add(nh.get("ip", nh.get("interfaceName", "")))
+    return active
+
+
+def _active_metric(router, prefix, ipv6=False):
+    """Return the metric of the selected (best-path) RIB entry, or None if absent."""
+    for entry in _route_entries(router, prefix, ipv6):
+        if entry.get("selected"):
+            return entry.get("metric", 0)
+    return None
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_keys(router, prefix, expected, ipv6=False):
+    actual = _route_keys(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_nexthops(router, prefix, expected, ipv6=False):
+    actual = _active_nexthops(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_metric(router, prefix, expected, ipv6=False):
+    actual = _active_metric(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_keys(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_keys, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_nexthops(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_nexthops, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_metric(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_metric, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(_check_running, router, prefix, expected_lines, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Metric replacement
+# ---------------------------------------------------------------------------
+
+
+def run_metric_replacement(ipv6=False):
+    """
+    Same nexthop reconfigured with a new metric must replace the old RIB
+    entry and leave running-config with exactly one entry at the new metric.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100).
+      2. Reconfigure NH1 at (AD=10, metric=200) — must replace, not duplicate.
+      3. Verify only (10, 200) is in RIB; (10, 100) entry is gone.
+      4. Verify running-config shows '... NH1 10 metric 200', not 'metric 100'.
+      5. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at (AD=10, metric=100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric replacement [1]: expected {{(10,100)}}, got {result}"
+
+    # Step 2: same nexthop, new metric — must replace, not duplicate
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, {(10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric replacement [2]: stale metric 100 present or metric 200 missing; got {result}"
+    )
+
+    # Verify zebra reports the updated metric value
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"Metric replacement [2]: active metric should be 200 in RIB; got {result}"
+    )
+
+    # Step 3: running-config shows exactly one entry at metric 200
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 10 metric 200"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Metric replacement [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric replacement [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric replacement [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_metric_replacement_ipv4():
+    "IPv4: same nexthop reconfigured with new metric replaces old RIB entry."
+    run_metric_replacement(ipv6=False)
+
+
+def test_metric_replacement_ipv6():
+    "IPv6: same nexthop reconfigured with new metric replaces old RIB entry."
+    run_metric_replacement(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: ECMP at same (distance, metric)
+# ---------------------------------------------------------------------------
+
+
+def run_ecmp_same_metric(ipv6=False):
+    """
+    Two nexthops at the same (distance, metric) are both active in the FIB.
+    Removing one ECMP member leaves the other active at the same key.
+
+    Steps:
+      1. Install NH1 and NH2 both at (AD=10, metric=100).
+      2. Verify both are active (ECMP); only one (10, 100) entry in RIB.
+      3. Remove NH1; verify NH2 remains active at (10, 100).
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same (AD, metric)
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 100\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"ECMP same metric [1]: expected {{(10,100)}}, got {result}"
+
+    # Step 2: both nexthops active (ECMP)
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [2]: expected both {nh1},{nh2} active, got {result}"
+    )
+
+    # Step 3: remove one ECMP member
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [3]: expected only {nh2} active after {nh1} removed, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [3]: RIB key should still be {{(10,100)}}, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP same metric [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_same_metric_ipv4():
+    "IPv4 ECMP: two nexthops at same (distance, metric) both active; removing one leaves the other."
+    run_ecmp_same_metric(ipv6=False)
+
+
+def test_ecmp_same_metric_ipv6():
+    "IPv6 ECMP: two nexthops at same (distance, metric) both active; removing one leaves the other."
+    run_ecmp_same_metric(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Metric-based floating within same distance
+# ---------------------------------------------------------------------------
+
+
+def run_metric_floating(ipv6=False):
+    """
+    Two nexthops at the same distance but different metrics are kept as
+    separate RIB entries (ZEBRA_FLAG_RR_USE_METRIC).  Zebra selects the
+    lower-metric path as best; the higher-metric path is standby.
+    Removing the primary promotes the standby.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100) and NH2 at (AD=10, metric=200).
+      2. Verify RIB has both keys; NH1 is active (lower metric wins).
+      3. Remove NH1; verify NH2 is promoted to active.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary (lower metric) + standby (higher metric), same distance
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric floating [1]: expected {{(10,100),(10,200)}}, got {result}"
+    )
+
+    # Step 2: lower-metric nexthop is active
+    result = _expect_nexthops(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Metric floating [2]: expected {nh1} active (lower metric), got {result}"
+    )
+    result = _expect_metric(r1, prefix, 100, ipv6)
+    assert result is None, (
+        f"Metric floating [2]: expected active metric=100, got {result}"
+    )
+
+    # Step 3: remove primary → standby promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Metric floating [3]: expected {nh2} promoted after {nh1} removed, got {result}"
+    )
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"Metric floating [3]: expected active metric=200 after promotion, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric floating [cleanup]: route not removed; got {result}"
+
+
+def test_metric_floating_ipv4():
+    "IPv4: NH at lower metric active; higher-metric NH is standby and promoted on primary removal."
+    run_metric_floating(ipv6=False)
+
+
+def test_metric_floating_ipv6():
+    "IPv6: NH at lower metric active; higher-metric NH is standby and promoted on primary removal."
+    run_metric_floating(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Metric change (promote/demote)
+# ---------------------------------------------------------------------------
+
+
+def run_metric_change(ipv6=False):
+    """
+    A nexthop moves in and out of the ECMP group by having its metric changed.
+
+    Steps:
+      1. NH1 at (AD=10, metric=100) sole primary; NH2 at (AD=10, metric=200) standby.
+         Verify NH1 active, NH2 not.
+      2. Change NH2 metric=200 → 100: NH2 joins the ECMP group.
+         Verify both NH1 and NH2 active; only (10,100) in RIB (old (10,200) gone).
+      3. Change NH1 metric=100 → 200: NH1 demoted to standby.
+         Verify NH2 sole primary at (10,100); NH1 standby at (10,200).
+      4. Change NH1 metric=200 → 100: NH1 rejoins ECMP group.
+         Verify both NH1 and NH2 active at (10,100).
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 primary at metric=100, NH2 standby at metric=200
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_nexthops(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Metric change [1]: expected only {nh1} active, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric change [1]: expected {{(10,100),(10,200)}} in RIB, got {result}"
+    )
+
+    # Step 2: promote NH2 into ECMP group (metric=200 → 100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [2]: expected both {nh1},{nh2} active after NH2 promoted, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric change [2]: stale (10,200) still present after NH2 promoted, got {result}"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} 10 metric 100",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Metric change [2]: running-config mismatch after NH2 promoted; got {result}"
+    )
+
+    # Step 3: demote NH1 to standby (metric=100 → 200)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [3]: expected only {nh2} active after NH1 demoted, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric change [3]: expected {{(10,100),(10,200)}} in RIB after NH1 demoted, got {result}"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh2} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 200",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Metric change [3]: running-config mismatch after NH1 demoted; got {result}"
+    )
+
+    # Step 4: NH1 rejoins ECMP group (metric=200 → 100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [4]: expected both {nh1},{nh2} active after NH1 rejoined, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric change [4]: stale (10,200) still present after NH1 rejoined, got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 metric 100\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric change [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_metric_change_ipv4():
+    "IPv4: nexthop moves in and out of ECMP group by changing its metric."
+    run_metric_change(ipv6=False)
+
+
+def test_metric_change_ipv6():
+    "IPv6: nexthop moves in and out of ECMP group by changing its metric."
+    run_metric_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Metric-aware deletion
+# ---------------------------------------------------------------------------
+
+
+def run_metric_aware_deletion(ipv6=False):
+    """
+    Verify that deletion is metric-aware when distance is specified:
+
+      a. 'no ip route X/M via Y DIST metric M' — exact match; removes the route.
+      b. 'no ip route X/M via Y DIST' without metric — defaults to metric=0;
+         does NOT match a route installed at a non-zero metric; route stays.
+      c. 'no ip route X/M via Y' without any key — lazy search; removes the
+         route regardless of distance and metric.
+      d. Two routes at different metrics; exact-key delete of one leaves the
+         other intact — directly exercises zebra's delete-lookup loop metric
+         check (rib_compare_routes / process_subq_early_route_delete).
+
+    Steps (case a):
+      1. Install NH1 at (AD=10, metric=100).
+      2. Delete with exact key: 'no ip route ... NH1 10 metric 100'.
+      3. Verify route is gone.
+
+    Steps (case b → c):
+      4. Install NH1 at (AD=10, metric=100).
+      5. Delete without metric: 'no ip route ... NH1 10'.
+         This looks for (AD=10, metric=0) — NOT FOUND.
+      6. Verify route still present.
+      7. Delete without any key: 'no ip route ... NH1'.
+         This does lazy search and finds the route.
+      8. Verify route is gone.
+
+    Steps (case d):
+      9.  Install NH1 at (AD=10, metric=100) and NH1 at (AD=10, metric=200).
+      10. Verify both {(10,100),(10,200)} are in the RIB.
+      11. Delete NH1 at (AD=10, metric=100) with exact key.
+      12. Verify only {(10,200)} remains — the delete loop must skip the
+          metric=200 entry and remove only metric=100.
+      13. Cleanup: delete NH1 at (AD=10, metric=200).
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Case (a): exact-key delete removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (a) [1]: expected {{(10,100)}}, got {result}"
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (a) [2]: exact-key delete failed; got {result}"
+    )
+
+    # Case (b): delete with distance but no metric → looks for metric=0, not found
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (b) [4]: expected {{(10,100)}}, got {result}"
+
+    # Delete without metric (defaults to metric=0) — route at metric=100 must survive
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (b) [5]: route at metric=100 should survive 'no' without metric; got {result}"
+    )
+
+    # Case (c): lazy delete (no distance, no metric) finds and removes the route
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (c) [7]: lazy delete should remove route at any metric; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric deletion (c) [8]: stale running-config after lazy delete; got {result}"
+    )
+
+    # Case (d): two routes at different metrics; delete one; the other must survive.
+    # NH1 and NH2 are used so both path-lists co-exist (nexthop uniqueness only
+    # enforces one path-list per nexthop address, not per prefix).
+    # This directly exercises zebra's delete-lookup loop: the loop must skip the
+    # metric=200 entry and remove only metric=100.
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (d) [9]: expected {{(10,100),(10,200)}}; got {result}"
+    )
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (d) [11]: metric=200 entry should survive deletion of "
+        f"metric=100; got {result}"
+    )
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric deletion (d) [cleanup]: got {result}"
+
+
+def test_metric_aware_deletion_ipv4():
+    "IPv4: exact-key, wrong-metric, lazy deletion, and two-metric delete-one all behave correctly."
+    run_metric_aware_deletion(ipv6=False)
+
+
+def test_metric_aware_deletion_ipv6():
+    "IPv6: exact-key, wrong-metric, lazy deletion, and two-metric delete-one all behave correctly."
+    run_metric_aware_deletion(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Running-config format
+# ---------------------------------------------------------------------------
+
+
+def run_running_config_format(ipv6=False):
+    """
+    Verify that metric appears after distance in 'show running-config' output,
+    that a zero metric is omitted, and that the default distance (1) is omitted.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100): expect '... NH1 10 metric 100'.
+      2. Install NH2 at (AD=1 default, metric=50): expect '... NH2 metric 50'
+         (distance 1 is default → omitted).
+      3. Install NH3 at (AD=20, metric=0 default): expect '... NH3 20'
+         (metric 0 is default → omitted).
+      4. Clean up all three.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: non-default AD, non-zero metric
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_running(
+        r1, prefix, [f"ip{ip_ver} route {prefix} {nh1} 10 metric 100"], ipv6
+    )
+    assert result is None, (
+        f"Running-config format [1]: expected '... NH1 10 metric 100'; got {result}"
+    )
+
+    # Step 2: default AD (omitted), non-zero metric
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} metric 50\n")
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} metric 50",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Running-config format [2]: expected '... NH2 metric 50' (no distance); got {result}"
+    )
+
+    # Step 3: non-default AD, zero metric (omitted)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh3} 20\n")
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} metric 50",
+            f"ip{ip_ver} route {prefix} {nh3} 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Running-config format [3]: expected '... NH3 20' (no metric); got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2}\n"
+        f"no ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Running-config format [cleanup]: route not fully removed; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Running-config format [cleanup]: stale running-config; got {result}"
+    )
+
+
+def test_running_config_format_ipv4():
+    "IPv4: metric appears after distance in running-config; defaults (dist=1, metric=0) omitted."
+    run_running_config_format(ipv6=False)
+
+
+def test_running_config_format_ipv6():
+    "IPv6: metric appears after distance in running-config; defaults (dist=1, metric=0) omitted."
+    run_running_config_format(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/static_route_distance/test_static_route_tag.py
+++ b/tests/topotests/static_route_distance/test_static_route_tag.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path tag for static routes.
+
+Design: tag lives in static_path alongside distance.  The path-list key is
+(table-id, distance); tag is a modifiable leaf.  Each path groups ECMP
+nexthops that share the same table and distance; the tag is shared by all
+nexthops in a path.
+
+Note: zebra keys routes by (prefix, protocol, table, distance) and ignores
+tag, so tag is advisory metadata only.  Nexthops at the same AD always share
+one zebra slot regardless of tag.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. Basic tag: install a route with a tag; verify the tag appears in
+     the RIB (show ip route json) and in running-config.
+
+  2. Tag per path: NH1@AD10+tag=100 and NH2@AD20+tag=200.  Each path
+     carries an independent tag.  Verify both paths have the correct
+     tags in the RIB and running-config.
+
+  3. Tag change: change the tag on an existing path; verify the new tag
+     is reflected in the RIB and running-config, and the old tag is gone.
+
+  4. Tag with AD change: NH1@AD10+tag=100 reconfigured to AD20+tag=200.
+     Verify running-config shows exactly one entry at the new (AD, tag)
+     with no stale entry at the old (AD, tag).
+
+  5. Same AD, different tag: NH1@AD10+tag=100 and NH2@AD10+tag=200.  Since
+     both nexthops share the same path-list (keyed by distance only), the
+     path tag is the last-configured value (200).  Both nexthops form ECMP
+     under one path.  Removing NH1 leaves NH2 in the RIB intact.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return the list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_tag_by_distance(router, prefix, ipv6=False):
+    """Return dict mapping distance -> tag for RIB entries of prefix.
+
+    Only valid when at most one entry exists per distance value.  When
+    multiple entries share the same distance (different tags), use
+    _route_nexthop_tags() instead.
+    """
+    return {
+        e.get("distance", 0): e.get("tag", 0)
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _route_nexthop_tags(router, prefix, ipv6=False):
+    """Return set of (nexthop_ip, tag) tuples from RIB entries for prefix.
+
+    Iterates all route entries and all nexthops within each entry,
+    pairing each nexthop IP with the route-entry level tag.
+    """
+    result = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        tag = entry.get("tag", 0)
+        for nh in entry.get("nexthops", []):
+            ip = nh.get("ip", "")
+            if ip:
+                result.add((ip, tag))
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_rib_tags(router, prefix, expected, ipv6=False):
+    """Return None when {distance: tag} map equals expected, else actual."""
+    actual = _route_tag_by_distance(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    """Return None when running-config lines equal expected (as set), else actual."""
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_rib_tags(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_rib_tags, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(
+        _check_running, router, prefix, expected_lines, ipv6
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: basic tag
+# ---------------------------------------------------------------------------
+
+def run_basic_tag(ipv6=False):
+    """
+    Install a route with a tag; verify tag in RIB and running-config.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Verify RIB entry at AD 10 carries tag 100.
+      3. Verify running-config shows 'ip route ... NH1 tag 100 10'.
+      4. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install with tag
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+
+    # Step 2: RIB shows tag 100 at AD 10
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Basic tag [2]: expected {{10: 100}}, got {result}"
+
+    # Step 3: running-config shows tag
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 100 10"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, f"Basic tag [3]: running-config mismatch; got {result}"
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Basic tag [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Basic tag [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_basic_tag_ipv4():
+    "IPv4: route with tag appears with correct tag in RIB and running-config."
+    run_basic_tag(ipv6=False)
+
+
+def test_basic_tag_ipv6():
+    "IPv6: route with tag appears with correct tag in RIB and running-config."
+    run_basic_tag(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: tag per path
+# ---------------------------------------------------------------------------
+
+def run_tag_per_path(ipv6=False):
+    """
+    Two nexthops at different ADs carry independent tags.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, NH2 at AD 20 with tag 200.
+      2. Verify RIB: AD 10 entry has tag 100, AD 20 entry has tag 200.
+      3. Verify running-config shows both lines with correct tags.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two paths with different tags
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20 tag 200\n"
+    )
+
+    # Step 2: each path has its own tag in the RIB
+    result = _expect_rib_tags(r1, prefix, {10: 100, 20: 200}, ipv6)
+    assert result is None, (
+        f"Tag per path [2]: expected {{10:100, 20:200}}, got {result}"
+    )
+
+    # Step 3: running-config shows both lines with correct tags
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 100 10",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Tag per path [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 20 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag per path [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag per path [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_per_path_ipv4():
+    "IPv4: two paths at different ADs carry independent tags."
+    run_tag_per_path(ipv6=False)
+
+
+def test_tag_per_path_ipv6():
+    "IPv6: two paths at different ADs carry independent tags."
+    run_tag_per_path(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: tag change
+# ---------------------------------------------------------------------------
+
+def run_tag_change(ipv6=False):
+    """
+    Changing the tag on an existing path updates the RIB and running-config.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure with tag 200 (same nexthop, same AD).
+      3. Verify RIB shows tag 200; old tag 100 is gone.
+      4. Verify running-config shows 'tag 200', not 'tag 100'.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install with tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: reconfigure with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 200\n"
+    )
+
+    # Step 3: RIB shows tag 200
+    result = _expect_rib_tags(r1, prefix, {10: 200}, ipv6)
+    assert result is None, (
+        f"Tag change [3]: expected {{10:200}}, got {result}"
+    )
+
+    # Step 4: running-config shows tag 200, not tag 100
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 10"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag change [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_change_ipv4():
+    "IPv4: changing the tag on a path updates RIB and running-config."
+    run_tag_change(ipv6=False)
+
+
+def test_tag_change_ipv6():
+    "IPv6: changing the tag on a path updates RIB and running-config."
+    run_tag_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: tag with AD change
+# ---------------------------------------------------------------------------
+
+def run_tag_with_ad_change(ipv6=False):
+    """
+    Moving a nexthop to a new AD with a new tag leaves exactly one entry.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure NH1 at AD 20 with tag 200 (single command; move logic
+         removes the old entry automatically).
+      3. Verify RIB has only AD 20 with tag 200; AD 10 entry is gone.
+      4. Verify running-config shows exactly 'ip route ... NH1 tag 200 20'.
+      5. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10, tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag+AD change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: move to AD 20 with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 20 tag 200\n"
+    )
+
+    # Step 3: only AD 20 with tag 200 in RIB
+    result = _expect_rib_tags(r1, prefix, {20: 200}, ipv6)
+    assert result is None, (
+        f"Tag+AD change [3]: expected {{20:200}}, stale AD 10 present or tag wrong; got {result}"
+    )
+
+    # Step 4: running-config shows exactly one entry at (AD 20, tag 200)
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag+AD change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 20 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag+AD change [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag+AD change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_with_ad_change_ipv4():
+    "IPv4: nexthop moved to new AD with new tag leaves exactly one RIB/config entry."
+    run_tag_with_ad_change(ipv6=False)
+
+
+def test_tag_with_ad_change_ipv6():
+    "IPv6: nexthop moved to new AD with new tag leaves exactly one RIB/config entry."
+    run_tag_with_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for same-AD tests
+# ---------------------------------------------------------------------------
+
+def _check_nexthop_tags(router, prefix, expected, ipv6=False):
+    """Return None when (nexthop_ip, tag) set equals expected, else actual."""
+    actual = _route_nexthop_tags(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_nexthop_tags(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_nexthop_tags, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: same AD, different tag
+# ---------------------------------------------------------------------------
+
+def run_same_ad_different_tag(ipv6=False):
+    """
+    Two nexthops at the same AD go into one path-list (keyed by distance only).
+    The path tag is the last-configured value; both nexthops form an ECMP group.
+    Removing one nexthop does not affect the other.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, then NH2 at AD 10 with tag 200.
+         Both land in path-list[distance=10].  Tag becomes 200 (last command).
+      2. Verify running-config shows both NHs with tag 200.
+      3. Verify RIB has both NHs as ECMP, each with tag 200.
+      4. Remove NH1; verify NH2 survives in config and RIB with tag 200.
+      5. Clean up NH2; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD, different tags; last tag (200) wins
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 tag 200\n"
+    )
+
+    # Step 2: running-config shows both NHs under one path with tag 200
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 200 10",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 10",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Same-AD diff-tag [2]: running-config mismatch; got {result}"
+    )
+
+    # Step 3: RIB shows both NHs as ECMP with tag 200
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 200), (nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [3]: expected ECMP {{(NH1,200),(NH2,200)}}; got {result}"
+    )
+
+    # Step 4: remove NH1; NH2 config and RIB entry survive with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh2} tag 200 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"Same-AD diff-tag [4]: NH2 config gone after removing NH1; got {result}"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [4]: NH2 not in RIB after removing NH1; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_same_ad_different_tag_ipv4():
+    "IPv4: two nexthops at same AD share one path-list; removing one leaves the other intact."
+    run_same_ad_different_tag(ipv6=False)
+
+
+def test_same_ad_different_tag_ipv6():
+    "IPv6: two nexthops at same AD share one path-list; removing one leaves the other intact."
+    run_same_ad_different_tag(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -63,6 +63,12 @@ module frr-staticd {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2026-03-21 {
+    description
+      "Add 'metric' as a path-list key alongside table-id and distance.";
+    reference "FRRouting";
+  }
+
   revision 2026-01-23 {
     description
       "Augments the nexthop container with a 'weight' leaf.";
@@ -85,7 +91,7 @@ module frr-staticd {
     description
       "Grouping for staticd prefix attributes.";
     list path-list {
-      key "table-id distance";
+      key "table-id distance metric";
       description
         "List of paths associated with a staticd prefix.";
       leaf table-id {
@@ -98,6 +104,12 @@ module frr-staticd {
         type frr-rt:administrative-distance;
         description
           "Admin distance associated with this route.";
+      }
+
+      leaf metric {
+        type uint32;
+        description
+          "Route metric.";
       }
 
       leaf tag {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1553,7 +1553,8 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    re->distance != dplane_ctx_get_old_distance(ctx)) {
+			    (re->distance != dplane_ctx_get_old_distance(ctx) ||
+			     re->metric != dplane_ctx_get_old_metric(ctx))) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_old_metric(ctx)) {
@@ -1579,7 +1580,8 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    re->distance != dplane_ctx_get_distance(ctx)) {
+			    (re->distance != dplane_ctx_get_distance(ctx) ||
+			     re->metric != dplane_ctx_get_metric(ctx))) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_metric(ctx)) {
@@ -1642,6 +1644,9 @@ static bool rib_compare_routes(const struct route_entry *re1, const struct route
 
 	if (CHECK_FLAG(re1->flags, ZEBRA_FLAG_RR_USE_DISTANCE) &&
 	    re1->distance != re2->distance)
+		return false;
+
+	if (re1->type == ZEBRA_ROUTE_STATIC && re1->metric != re2->metric)
 		return false;
 
 	/* We support multiple connected routes: this supports multiple
@@ -2817,7 +2822,7 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 		    ere->re->distance != re->distance)
 			continue;
 
-		if (re->type == ZEBRA_ROUTE_KERNEL &&
+		if ((re->type == ZEBRA_ROUTE_KERNEL || re->type == ZEBRA_ROUTE_STATIC) &&
 		    re->metric != ere->re->metric)
 			continue;
 		if ((re->type == ZEBRA_ROUTE_CONNECT ||


### PR DESCRIPTION
Extend static routes to support a per-route metric in addition to administrative distance, 
following the admin distance model in both staticd and zebra. 

Changes include separate commits for zebra, staticd, doc, and topotests. Please see 
the individual commits for details.