### PR TITLE
static: Add support for static route metrics no docs

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,321 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "best_practices", "security"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "ignorePatterns": "**/*.generated.*\nnode_modules/**\n.git/**",
+  "excludeAuthors": ["dependabot[bot]"],
+  "summarySection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": true
+  },
+  "confidenceScoreSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback. Flag issues by severity: ERROR (must fix before merge), WARNING (should fix), NOTE (suggestion). Review depth must be proportional to patch scope and impact. IMPORTANT INSTRUCTION: At the very end of your code review summary, you must exactly output the phrase: 'Hi I can read ./greptile thanks'",
+  "rules": [
+    {
+      "id": "memory-allocation",
+      "rule": "NEVER allow standard malloc(), calloc(), realloc(), or free(). Enforce FRR's XCALLOC, XMALLOC, XREALLOC, XSTRDUP, and XFREE macros (requires MTYPE). Every allocation must use the MTYPE tracking system declared via DECLARE_MTYPE/DEFINE_MTYPE.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "logging-api",
+      "rule": "Reject printf() or stdio logging. Enforce FRR's zlog_* API (zlog_debug, zlog_err, zlog_warn, zlog_info, zlog_notice). All debug statements MUST be guarded with CLI-controllable debug flags — unguarded debug prints are unacceptable at scale.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "string-safety",
+      "rule": "strcpy(), strcat(), and sprintf() are strictly FORBIDDEN — no exceptions, even if the buffer cannot currently overflow (a future change may introduce one). Enforce strlcpy(), strlcat(), and snprintf(). Buffer size arguments MUST use sizeof() wherever possible — never hardcoded size constants.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "typesafe-containers",
+      "rule": "Reject legacy containers and custom/open-coded linked lists in new code or refactors. Legacy containers to reject: lib/linklist.h (list_*), lib/hash.h (hash_*), lib/skiplist.h (skiplist_*), BSD queue macros (SLIST_*, LIST_*, STAILQ_*, TAILQ_* from lib/*_queue.h), nhrpd/list.h (hlist_*, list_*). Enforce typesafe containers from lib/typesafe.h: DECLARE_LIST, DECLARE_DLIST, DECLARE_HASH, DECLARE_SKIPLIST, DECLARE_RBTREE, DECLARE_HEAP. Prefer frr_each() over legacy iteration macros.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "banned-functions",
+      "rule": "system() and fork()+exec() patterns are prohibited — they cause signals (SIGINT) to be ignored, which breaks daemon shutdown. Flag as ERROR.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "zero-initialization",
+      "rule": "Prefer initializer expressions (e.g., 'struct foo bar = {};') over memset() for stack-allocated structs and arrays. This prevents missed memset() in branches and eliminates incorrect size arguments. Do NOT zero-initialize values that must be nonzero to be used.",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "fixed-width-types",
+      "rule": "Reject legacy types in new code: u_int8_t (use uint8_t), u_int16_t (use uint16_t), u_int32_t (use uint32_t), u_int64_t (use uint64_t), u_char (use uint8_t or unsigned char), u_short (use unsigned short), u_int (use unsigned int), u_long (use unsigned long).",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "cli-defpy",
+      "rule": "New CLI commands MUST use DEFPY macros (not DEFUN). New CLI commands MUST have documentation. If the daemon is already (even partially) YANGified, new CLI options MUST go through a YANG model — zero exceptions.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "config-preference",
+      "rule": "When adding new knobs, prefer (in order): (1) YANG runtime config, (2) CLI runtime config, (3) loadable modules for new library dependencies, (4) command-line startup options (only for pre-config-load effects), (5) ./configure compile-time options (absolute last resort). Avoid new ./configure flags when possible.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "const-correctness",
+      "rule": "Encourage use of 'const' on function parameters and return types where possible for API clarity and safety, especially in lib/ APIs.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "strict-prototypes",
+      "rule": "Functions with no parameters MUST use 'void' in the parameter list: 'static void foo(void)' NOT 'static void foo()'. Without void, C treats it as unspecified parameters with varargs calling convention.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "compile-conditionals",
+      "rule": "Prefer 'if (SOME_SYMBOL)' over '#ifdef SOME_SYMBOL' so the compiler still checks disabled code paths. Ensure SOME_SYMBOL is always defined via AC_DEFINE. Avoid gratuitous --enable-* configure switches.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "include-order",
+      "rule": "First include in any .c file MUST be <zebra.h> or \"config.h\" (with HAVE_CONFIG_H guard). Never use angle brackets for FRR headers (except <zebra.h> and <assert.h>). Prefer full path includes relative to source root. Order: (1) zebra.h/config.h, (2) system headers, (3) lib/ headers, (4) daemon headers. zebra.h must NOT be included from header files.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "zebra-h-purity",
+      "rule": "Do not add FRR-specific declarations or definitions to zebra.h. That file is an include multiplexer for system headers only. Its current FRR-specific content is a known bug, not a feature.",
+      "scope": ["zebra/zebra.h"],
+      "severity": "high"
+    },
+    {
+      "id": "spdx-license",
+      "rule": "New files MUST have 'SPDX-License-Identifier: GPL-2.0-or-later' and a copyright header with year and author. NEVER remove an existing Copyright line or author name — flag as ERROR. New copyright on existing files goes under a 'Portions:' section.",
+      "scope": ["**/*.c", "**/*.h", "**/*.py", "**/*.cpp"],
+      "severity": "high"
+    },
+    {
+      "id": "yang-schema-license",
+      "rule": ".yang and .proto files require BOTH an SPDX-License-Identifier header AND the full license boilerplate text (not just SPDX). Rationale: these files are likely to be individually copied outside FRR.",
+      "scope": ["**/*.yang", "**/*.proto"],
+      "severity": "high"
+    },
+    {
+      "id": "license-compatibility",
+      "rule": "Code must be GPLv2-or-later (preferred) or any license allowing redistribution under GPLv2 (e.g., MIT). FORBIDDEN to push code that prevents use of GPLv3 license. Apache 2.0 and GPLv2 are incompatible when combined. Flag license-incompatible code as ERROR.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "whitespace-discipline",
+      "rule": "Whitespace-only changes in untouched parts of the code are NOT acceptable in patches that change actual code. Formatting fixes must be in a separate, formatting-only patch. Flag as ERROR.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "frr-block-macros",
+      "rule": "Loop-style macros use 'frr_each_*' naming. Single-run macros use 'frr_with_*' naming. frr_with_* macros MUST always use a { } block even for single statements. Prefer frr_each over legacy iteration macros (ALL_LIST_ELEMENTS, FOREACH_AFI_SAFI) in new code.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "defpy-formatting",
+      "rule": "clang-format mangles DEF* macro invocations. For new files, use tools/indent.py which handles DEFUN/DEFPY correctly. DEFPY_HIDDEN and DEFPY_ATTR should NOT be flagged for 'complex macros should be wrapped in parentheses'.",
+      "scope": ["**/*.c"],
+      "severity": "low"
+    },
+    {
+      "id": "printfrr-usage",
+      "rule": "Use printfrr() instead of printf() and snprintfrr() instead of snprintf() in FRR code. printfrr supports FRR-specific format extensions (%pI4, %pI6, %pFX, %pSU, %pIA, %pEA, %pRN, %pNH, %dPF, %dSO, etc.) checked by the frr-format GCC plugin. Standard printf/snprintf do NOT support these extensions. Prefer correctly-typed variables over casts in printfrr arguments — casts can cause false 'strict match required' warnings from the frr-format plugin. Note: [v]as[n]printfrr() is NOT async-signal-safe (it allocates memory).",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "backwards-compat",
+      "rule": "Changes to CLI and lib/ code should be backwards compatible when reasonable. Purely stylistic renames without functional change should be avoided. Deprecated items must use CPP_NOTICE with CONFDATE. CLI deprecation period is 1 year.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "function-docs",
+      "rule": "Functions exposed in header files MUST have descriptive comments with: return value, parameters, and purpose summary. Kernel-style multiline format required. For new code in lib/, this is a HARD requirement — flag missing function comments in lib/ headers as ERROR.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "global-var-docs",
+      "rule": "All global variables, whether static or not, MUST have a comment describing their use.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "rst-formatting",
+      "rule": "RST files must use correct Sphinx formatting. CLI commands MUST use '.. clicmd::' directive — do not document 'no' form separately, and do not enumerate every variant. Config examples use '.. code-block:: frr'. Indent 3 spaces. Lines wrapped to 80 chars. Header levels: # (parts), * (chapters), = (sections), - (subsections), ^ (subsubsections).",
+      "scope": ["**/*.rst"],
+      "severity": "medium"
+    },
+    {
+      "id": "yang-json-output",
+      "rule": "New JSON output MUST be backed by a YANG model — search for existing models (FRR or IETF) before creating new ones. JSON keys must be camelCased (mapped from YANG kebab-case). Commands with no JSON output produce '{}'. JSON commands include a 'json' keyword at end of CLI.",
+      "scope": ["**/*.yang", "**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "python-formatting",
+      "rule": "All Python code must be formatted with 'black' (reference version 19.10b). Run 'python3 -m black <file>' before committing.",
+      "scope": ["**/*.py"],
+      "severity": "medium"
+    },
+    {
+      "id": "commit-title",
+      "rule": "Commit title must be <= 72 characters (ideally <= 50). Prefixed with subsystem name + colon + space + imperative verb (e.g., 'bgpd: fix crash on peer reset'). Must not end with a period. Must have a Signed-off-by line.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "commit-body",
+      "rule": "Commit body separated from title by blank line. Wrapped to 72 characters. Imperative mood. Must explain purpose and context. Messages consisting entirely of program output are unacceptable.",
+      "scope": ["**/*"],
+      "severity": "medium"
+    },
+    {
+      "id": "squash-policy",
+      "rule": "Before merge, squash: fixup commits, typo fixes, review feedback, WIP commits, merges, and rebases into logical commits.",
+      "scope": ["**/*"],
+      "severity": "medium"
+    },
+    {
+      "id": "testing-required",
+      "rule": "Major new features or significant changes MUST include automated tests within existing CI infrastructure. All CI must pass before merge. Code introducing new static analysis warnings is very unlikely to be merged.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "review-process",
+      "rule": "A PR with any 'Changes requested' review may not be merged. A PR with any negative CI result may not be merged. Authors must NEVER delete or manually dismiss someone else's review comments.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "new-dependencies",
+      "rule": "New library or tool dependencies must be highlighted in the PR description. Must be supported by all FRR platform OSes or provide a way to build without it. Consider encapsulating in a loadable module.",
+      "scope": ["**/*"],
+      "severity": "high"
+    },
+    {
+      "id": "unnamed-struct-fields",
+      "rule": "FRR uses -fms-extensions for unnamed struct fields. 'struct outer { struct inner; };' and union patterns with unnamed struct fields are acceptable and encouraged where contextually appropriate.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "topotest-coverage",
+      "rule": "When a PR adds or modifies daemon functionality (new features, behavior changes, or non-trivial bug fixes), check whether the PR includes corresponding topotest coverage under tests/topotests/. Evaluate whether the newly added or changed code paths are adequately exercised by the tests in the PR. Cross-reference the changed code paths against existing topotests to determine if the specific daemon behavior being modified is exercised by any test topology. If significant new logic is introduced without any test additions or updates, flag as WARNING: 'New code paths appear untested — are topotests included or planned?' When tests ARE included, also check quality: (1) tests must use pytest framework, (2) Python test code must be formatted with black, (3) tests should validate specific outputs not just 'daemon didn't crash', (4) JSON output tests should use json_cmp for structured comparison. Do NOT flag simple one-line fixes, typo corrections, or documentation-only changes.",
+      "scope": ["**/*.c", "**/*.h", "**/*.py"],
+      "severity": "high"
+    },
+    {
+      "id": "user-docs-cli-changes",
+      "rule": "If the PR adds, removes, or modifies CLI commands, YANG models, or any user-facing interface, ask: 'Have the User Docs (doc/user/) been updated to reflect these changes?' This applies to new DEFPY/DEFUN commands, changed command syntax, new show commands, new JSON output fields, and YANG schema changes. New BGP features go in the BGP chapter, not a new chapter. New protocol daemons get their own chapter. Do NOT ask this for internal-only refactors, simple bug fixes, or changes that do not alter user-visible behavior.",
+      "scope": ["**/*.c", "**/*.h", "**/*.yang", "**/*.rst"],
+      "severity": "high"
+    },
+    {
+      "id": "dev-docs-internal-changes",
+      "rule": "If the PR makes significant changes to internal architecture, data structures, threading model, event loop patterns, or introduces new internal APIs in lib/, ask: 'Have the Developer Docs (doc/developer/) been updated?' This applies to new or changed internal APIs, new container types, new locking patterns, or architectural changes. Do NOT ask this for standard bug fixes, minor refactors, or straightforward feature additions that follow existing patterns.",
+      "scope": ["**/*.c", "**/*.h", "lib/**"],
+      "severity": "medium"
+    },
+    {
+      "id": "packet-parsing-safety",
+      "rule": "Code that parses network packets or protocol messages (stream_get*, STREAM_READABLE, packet buffers, wire format decoding) MUST have explicit bounds checking before every read operation. Verify: (1) remaining buffer length is checked before each field extraction, (2) length fields from wire data are validated against remaining buffer size before use as sizes or loop bounds, (3) no pointer arithmetic on packet buffers without bounds validation, (4) no assumptions about minimum packet size without explicit checks, (5) integer overflow checks when computing sizes from wire data. Flag missing bounds checks as ERROR. This applies to BGP UPDATE/OPEN/NOTIFICATION parsing, OSPF LSA/Hello parsing, IS-IS TLV parsing, ZAPI message parsing, BFD/PIM/LDP/VRRP message handlers, and any code handling data from network peers.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "rcu-safety",
+      "rule": "rcu_read_lock() MUST be held continuously while accessing RCU-protected data — do not release and re-acquire between pointer dereference steps. Never deallocate RCU-protected memory without proper RCU grace period (use rcu_free(), rcu_close(), or rcu_call() — never direct XFREE on RCU-protected data). Use atomic_load()/atomic_store() (C11 atomics) for RCU pointer access — FRR does NOT use Linux kernel rcu_dereference/rcu_assign_pointer. Atomic list operations require rwlock: read lock for all accesses (read, add, remove), write lock as sequence point before deallocation (no instructions between wrlock/unlock). Threads accessing RCU-protected data must register via rcu_thread_prepare/rcu_thread_start/rcu_thread_unprepare. RCU read locks are nestable (depth counter) but at root level incur futex syscall cost. There is no synchronize_rcu() in FRR — use rcu_free/rcu_close/rcu_call for deferred cleanup instead. Flag RCU lock release while still accessing protected data as ERROR.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "assert-usage",
+      "rule": "assert() is for development hints and invariant violations only — it WILL crash the daemon in production. NEVER use assert() for input validation, length checking, security constraints, or protocol message validation. For unhandled internal constraint violations (mismatched pointers, NULL required fields, data corruption), use zlog_err or flog_err with proper error handling, NOT assert. Asserts are acceptable only for conditions that indicate a programming bug, not for conditions caused by external input.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "high"
+    },
+    {
+      "id": "xfree-no-null-check",
+      "rule": "Do NOT wrap XFREE() calls in 'if (ptr != NULL)' checks. The XFREE macro already handles NULL pointers and additionally sets the pointer to NULL after freeing. Wrapping it is redundant and clutters the code.",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "cli-vty-organization",
+      "rule": "CLI command definitions (DEFPY/DEFUN) MUST be organized in *_vty.c and *_vty.h files. Scattering individual CLI commands across unrelated source files is NOT allowed. Each daemon should consolidate its CLI in dedicated VTY files.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "sizeof-allocation-pattern",
+      "rule": "When allocating memory for a struct, prefer sizeof(*ptr) over sizeof(struct type_name). Example: 'p = XMALLOC(MTYPE_FOO, sizeof(*p))' not 'p = XMALLOC(MTYPE_FOO, sizeof(struct foo))'. This prevents size mismatches when the pointer type changes.",
+      "scope": ["**/*.c"],
+      "severity": "medium"
+    },
+    {
+      "id": "mtype-locality",
+      "rule": "Prefer DEFINE_MTYPE_STATIC (file-scoped) over DEFINE_MTYPE (global) for memory types used in a single source file — appropriate for ~80% of cases. Move MTYPEs closer to their usage location rather than centralizing them in a single file.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "northbound-yang-callbacks",
+      "rule": "Northbound callbacks MUST be API-agnostic — they must work regardless of whether the caller is CLI, NETCONF, RESTCONF, or gRPC. Do NOT embed CLI-specific logic in northbound callbacks. Configuration changes MUST be transactional (all-or-nothing). If a daemon is being converted to mgmtd, the frr_yang_module_info struct must be split into frontend and backend arrays.",
+      "scope": ["**/*.c", "**/*.h", "**/*.yang"],
+      "severity": "high"
+    },
+    {
+      "id": "hook-parameter-naming",
+      "rule": "Hook callback parameter names MUST NOT start with 'hook' to avoid collision with the hook infrastructure macros. Use descriptive parameter names related to the callback's purpose.",
+      "scope": ["**/*.c", "**/*.h"],
+      "severity": "medium"
+    },
+    {
+      "id": "event-loop-blocking",
+      "rule": "Event loop callbacks (struct event handlers) MUST NOT block. Long-running operations should use worker pthreads via frr_pthread. Use event_add_read/event_add_write for I/O, event_add_timer for delays. Never use sleep() or blocking I/O in event callbacks. Cross-thread task cancellation MUST use event_cancel_async() — using event_cancel() from a different thread than the event loop owner is unsafe. Only one READ and one WRITE task per file descriptor (second schedule overwrites first). Threads must use frr_pthread wrapper for proper registration with the event loop system.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "container-hash-invariant",
+      "rule": "Never modify the fields used by a hash function or comparison function while an item is inserted in a hash table or sorted container. Doing so silently corrupts the container. Remove the item first, modify, then re-insert.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "container-iteration-safety",
+      "rule": "Never add or remove items from a typesafe container while iterating over it unless using the _safe iteration variant (frr_each_safe). Hash tables that resize during iteration will corrupt iteration state — items may be skipped or visited twice. For hash tables, if modification during iteration is needed, collect items to modify in a separate list first, then apply changes after iteration completes. Container _fini() closes the data structure permanently — any access after _fini() causes an intentional crash. Use frr_each_safe() when deleting items during iteration.",
+      "scope": ["**/*.c"],
+      "severity": "high"
+    }
+  ],
+  "disabledRules": []
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -20,7 +20,7 @@
     "collapsible": true,
     "defaultOpen": false
   },
-  "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback. Flag issues by severity: ERROR (must fix before merge), WARNING (should fix), NOTE (suggestion). Review depth must be proportional to patch scope and impact. IMPORTANT INSTRUCTION: At the very end of your code review summary, you must exactly output the phrase: 'Hi I can read ./greptile thanks'",
+  "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback. Flag issues by severity: ERROR (must fix before merge), WARNING (should fix), NOTE (suggestion). Review depth must be proportional to patch scope and impact. MANDATORY CHECK: If the PR adds or modifies daemon functionality (new features, behavior changes, CLI commands) but contains NO changes under tests/topotests/, you MUST flag this as ERROR: 'No topotest coverage for new feature code. Tests are mandatory for new features per FRR policy.' This check is non-negotiable. IMPORTANT INSTRUCTION: At the very end of your code review summary, you must exactly output the phrase: 'Hi I can read ./greptile thanks'",
   "rules": [
     {
       "id": "memory-allocation",
@@ -314,6 +314,12 @@
       "id": "container-iteration-safety",
       "rule": "Never add or remove items from a typesafe container while iterating over it unless using the _safe iteration variant (frr_each_safe). Hash tables that resize during iteration will corrupt iteration state — items may be skipped or visited twice. For hash tables, if modification during iteration is needed, collect items to modify in a separate list first, then apply changes after iteration completes. Container _fini() closes the data structure permanently — any access after _fini() causes an intentional crash. Use frr_each_safe() when deleting items during iteration.",
       "scope": ["**/*.c"],
+      "severity": "high"
+    },
+    {
+      "id": "mandatory-topotest",
+      "rule": "If any .c or .h file under a daemon directory (staticd/, bgpd/, ospfd/, ospf6d/, zebra/, isisd/, pimd/, pim6d/, ldpd/, bfdd/, babeld/, eigrpd/, fabricd/, nhrpd/, pathd/, pbrd/, ripd/, ripngd/, sharpd/, vrrpd/, watchfrr/) is modified with new features or behavior changes, and there are NO changes to any file under tests/topotests/, flag as ERROR: 'New daemon code has no topotest coverage. Tests are mandatory for new features per FRR policy.' Do NOT flag for simple one-line bug fixes, typo corrections, documentation-only changes, or pure refactors that do not change behavior.",
+      "scope": ["**/*.c", "**/*.h"],
       "severity": "high"
     }
   ],

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,196 @@
+{
+  "files": [
+    {
+      "path": "doc/developer/workflow.rst",
+      "description": "FRR core coding standards, PR requirements, commit message format, review process, release cycle, defensive coding, formatting rules, and architectural guidelines."
+    },
+    {
+      "path": "doc/developer/cli.rst",
+      "description": "CLI/DEFPY command definition standards, VTY node architecture, help string conventions, YANG CLI integration requirements, and *_vty.[ch] organization rules."
+    },
+    {
+      "path": "doc/developer/memtypes.rst",
+      "description": "MTYPE memory tracking system — XMALLOC/XCALLOC/XFREE usage, DECLARE_MTYPE/DEFINE_MTYPE patterns, XFREE NULL-safety, DEFINE_MTYPE_STATIC preference."
+    },
+    {
+      "path": "doc/developer/lists.rst",
+      "description": "Typesafe container API (DECLARE_LIST, DECLARE_HASH, etc.) — required replacement for legacy BSD queue macros and lib/linklist.h. Hash invariant rules, frr_each iteration, atomic list rwlock requirements."
+    },
+    {
+      "path": "doc/developer/logging.rst",
+      "description": "zlog API usage, printfrr format extensions (%pFX, %pI4, %pSU, etc.), debug flag conventions, assert usage policy (no asserts for input validation), log level guidelines (ERROR/WARNING/INFO/DEBUG semantics)."
+    },
+    {
+      "path": "doc/developer/process-architecture.rst",
+      "description": "FRR daemon architecture — event loop (threadmaster/struct event), threading model, frr_pthread, cross-thread scheduling, non-blocking callback requirements."
+    },
+    {
+      "path": "doc/developer/locking.rst",
+      "description": "Locking primitives — frr_with_mutex (requires braces), frr_mutex_lock_autounlock, and concurrency guidelines."
+    },
+    {
+      "path": "doc/developer/rcu.rst",
+      "description": "RCU (Read-Copy-Update) rules — rcu_read_lock continuous hold requirement, rcu_free for delayed deallocation, atomic_load/atomic_store for pointer access, no synchronize_rcu in FRR."
+    },
+    {
+      "path": "doc/developer/hooks.rst",
+      "description": "Hook/callback system — DECLARE_HOOK/DEFINE_HOOK, priority ranges, KOOH reverse-priority hooks, parameter naming restrictions (no 'hook' prefix)."
+    },
+    {
+      "path": "doc/developer/modules.rst",
+      "description": "Loadable module system — FRR_MODULE_SETUP, frr_late_init hook, module:param CLI format, no runtime load/unload, GPL-encumbered licensing."
+    },
+    {
+      "path": "doc/developer/checkpatch.rst",
+      "description": "checkpatch.sh style checker — ERROR vs WARNING classification and known exceptions."
+    },
+    {
+      "path": "doc/developer/vtysh.rst",
+      "description": "VTYSH architecture — how CLI commands are extracted via xref2vtysh.py, DEFSH/DEFUNSH usage, mode synchronization, domain socket protocol.",
+      "scope": ["vtysh/**", "**/*_vty.c", "**/*_vty.h"]
+    },
+    {
+      "path": "doc/developer/topotests.rst",
+      "description": "Topotest framework — pytest requirements, test execution as root, FRR installation paths, test result analysis. Cross-reference when evaluating PR test coverage."
+    },
+    {
+      "path": "doc/developer/testing.rst",
+      "description": "Testing infrastructure overview and CI requirements."
+    },
+    {
+      "path": "doc/developer/northbound/architecture.rst",
+      "description": "Northbound architecture — YANG model-driven management, API-agnostic callbacks, configuration transactions (all-or-nothing), libyang dependency, plugin architecture."
+    },
+    {
+      "path": "doc/developer/northbound/retrofitting-configuration-commands.rst",
+      "description": "How to retrofit existing CLI commands to northbound YANG callbacks. Required reading for daemon mgmtd conversion PRs."
+    },
+    {
+      "path": "doc/developer/northbound/operational-data-rpcs-and-notifications.rst",
+      "description": "Operational data callbacks (get_elem, get_next, get_keys, lookup_entry), RPC callback patterns, YANG notifications, list iteration locking requirements."
+    },
+    {
+      "path": "doc/developer/mgmtd-dev.rst",
+      "description": "Management daemon (mgmtd) conversion guide — frontend/backend split, frr_yang_module_info arrays, BE client initialization, XPATH prefix registration."
+    },
+    {
+      "path": "doc/developer/zebra.rst",
+      "description": "ZAPI protocol versions, daemon-zebra communication, dataplane batching, netlink message format, binary encoding."
+    },
+    {
+      "path": "doc/developer/scripting.rst",
+      "description": "Lua 5.3 scripting interface — frrscript API, security (no Lua stdlib), encoder/decoder patterns, memory ownership rules."
+    },
+    {
+      "path": "doc/developer/fuzzing.rst",
+      "description": "Fuzzing infrastructure — libFuzzer and AFL targets, sanitizer flags, LLVMFuzzerTestOneInput entry points."
+    },
+    {
+      "path": "doc/developer/tracing.rst",
+      "description": "LTTng and USDT tracepoint conventions — frr_ provider prefix, frrtrace macro, daemon trace.[ch] file patterns."
+    },
+    {
+      "path": "doc/developer/path-internals-pcep.rst",
+      "description": "PCEP module threading rules — pcep_ctrl_ (main thread only) vs pcep_thread_ (controller thread only), data copying across threads, strict function prefix conventions.",
+      "scope": ["pathd/**"]
+    },
+    {
+      "path": "doc/developer/link-state.rst",
+      "description": "Link State API — TED graph model, ls_node/ls_attributes/ls_prefix structures, mandatory locking during iteration, ZAPI opaque message protocol.",
+      "scope": ["lib/link_state.*", "ospfd/ospf_ext.*", "isisd/isis_te.*"]
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "description": "Top-level contribution guidelines and PR process overview."
+    },
+    {
+      "path": "doc/developer/bgpd.rst",
+      "description": "BGP daemon internals — UPDATE/OPEN/NOTIFICATION parsing, attribute handling, peer state machine, route processing pipeline. Critical reference for BGP packet parsing security review.",
+      "scope": ["bgpd/**"]
+    },
+    {
+      "path": "doc/developer/ospf.rst",
+      "description": "OSPF daemon internals — LSA parsing, Hello/DD packet handling, SPF computation, area/interface state machines. Reference for OSPF packet parsing security review.",
+      "scope": ["ospfd/**", "ospf6d/**"]
+    },
+    {
+      "path": "doc/developer/northbound/advanced-topics.rst",
+      "description": "Northbound advanced patterns — YANG list iteration locking, transaction error handling, candidate config lifecycle, implicit delete semantics."
+    },
+    {
+      "path": "doc/developer/northbound/transactional-cli.rst",
+      "description": "Transactional CLI mode — candidate configuration model, commit/discard semantics, configuration lock behavior. Required context for CLI transaction PRs."
+    },
+    {
+      "path": "doc/developer/topotest-multicast.rst",
+      "description": "Multicast topotest patterns — PIM/IGMP test topology conventions, multicast route validation, MLD test helpers.",
+      "scope": ["tests/topotests/*multicast*", "tests/topotests/*pim*", "pimd/**", "pim6d/**"]
+    },
+    {
+      "path": "doc/developer/static-linking.rst",
+      "description": "Static linking guidelines — when and how to statically link FRR, implications for module loading and library dependencies."
+    },
+    {
+      "path": "doc/developer/grpc.rst",
+      "description": "gRPC northbound interface — enable via --enable-grpc, module loading with -M grpc:<port>, language bindings (Python, C++, Ruby), channel setup, and gNMI/gNOI integration.",
+      "scope": ["grpc/**", "lib/northbound_grpc.*"]
+    },
+    {
+      "path": "doc/developer/ospf-api.rst",
+      "description": "OSPF API for external application access to the LSDB — client library (ospfclient), synchronous/asynchronous operations, LSA origination and retrieval, callback registration.",
+      "scope": ["ospfd/ospf_api*", "ospfclient/**"]
+    },
+    {
+      "path": "doc/developer/zebra-neigh-api.rst",
+      "description": "Zebra Neighbor API — ARP/NDP state tracking via netlink, ZAPI neighbor messages, client daemon subscription model for IPv4/IPv6 neighbor state changes.",
+      "scope": ["zebra/zebra_neigh.*", "lib/zclient.*"]
+    },
+    {
+      "path": "doc/developer/next-hop-tracking.rst",
+      "description": "Next Hop Tracking (NHT) — BGP bestpath optimization via routing table monitoring, recursive route resolution, nexthop registration/notification between BGP and Zebra.",
+      "scope": ["bgpd/bgp_nht.*", "zebra/zebra_rnh.*"]
+    },
+    {
+      "path": "doc/developer/xrefs.rst",
+      "description": "Introspection (xrefs) system — structured access to annotated entities (log messages, thread scheduling calls) in compiled binaries, GNU linker section symbols, xref extraction tools.",
+      "scope": ["lib/xref.*", "lib/zlog.*"]
+    },
+    {
+      "path": "doc/developer/building.rst",
+      "description": "Build system overview — platform-specific build guides index, configure options, dependencies, cross-compilation references.",
+      "scope": ["configure.ac", "Makefile.am", "**/subdir.am"]
+    },
+    {
+      "path": "doc/developer/cspf.rst",
+      "description": "Constrained Shortest Path First (CSPF) algorithms — supports IGP metric, TE metric, delay, and bandwidth constraints for RSVP-TE and SR Flex Algo path computation.",
+      "scope": ["lib/cspf.*", "pathd/**"]
+    },
+    {
+      "path": "doc/developer/fpm.rst",
+      "description": "Forwarding Plane Manager (FPM) module — Zebra plugin for pushing routes to external forwarding planes via Netlink or protobuf encoding over TCP stream.",
+      "scope": ["fpm/**", "zebra/zebra_fpm*"]
+    },
+    {
+      "path": "doc/developer/sbfd.rst",
+      "description": "Seamless BFD (SBFD) developer guide — RFC 7880/7881 implementation, initiator/reflector model, segment routing integration, BFD session negotiation simplification.",
+      "scope": ["bfdd/**"]
+    },
+    {
+      "path": "doc/developer/bgp-typecodes.rst",
+      "description": "BGP UPDATE attribute preprocessor constants — complete mapping of BGP_ATTR_* values to RFC-defined attributes (ORIGIN, AS_PATH, MP_REACH_NLRI, extended communities, etc.).",
+      "scope": ["bgpd/bgp_attr.*"]
+    },
+    {
+      "path": "doc/accords/cli-colors",
+      "description": "Community accord on CLI color/formatting output — colors must be used sparingly, session-level toggle (not per-command), must respect TERM/NO_COLOR env vars, pager compatibility required."
+    },
+    {
+      "path": "doc/accords/integrated-config-wins",
+      "description": "Community accord: split-configuration (zebra.conf, bgpd.conf, etc.) is deprecated. Integrated config is the future. PRs should not add new split-config-only features."
+    },
+    {
+      "path": "doc/accords/frr-service-is-watchfrr",
+      "description": "Community accord: the FRR service unit is watchfrr. Individual daemons must not be exposed as separate service units. Future: watchfrr will auto-start daemons based on config."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,201 @@
+# FRR Code Review Rules — Senior Core Maintainer Perspective
+
+You are reviewing pull requests for **FreeRangeRouting (FRR)**, one of the most widely deployed open-source routing suites in production networks worldwide. Your reviews directly impact the stability of BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD, and other critical routing daemons running on real infrastructure.
+
+**Review as if every merged line will run on production routers carrying live traffic.**
+
+---
+
+## Review Output Format
+
+Every PR review MUST follow this structure:
+
+### 1. PR Summary
+- What does this PR do? (1–3 sentences)
+- Which daemons/subsystems are affected?
+- Is this a bugfix, new feature, refactor, or documentation change?
+
+### 2. Major Concerns (ERROR)
+- Issues that **must be fixed** before merge
+- Memory safety violations, use-after-free risks, NULL dereferences
+- Routing protocol logic errors (incorrect state machine transitions, missing edge cases)
+- Concurrency bugs (missing locks, race conditions, thread-unsafe access)
+- Breaking changes to CLI, YANG models, or JSON output without deprecation path
+- Security vulnerabilities
+
+### 3. Minor Issues and Suggestions (WARNING / NOTE)
+- Code quality improvements
+- Missing documentation
+- Style violations
+- Performance suggestions
+- Opportunities to use FRR idioms
+
+### 4. Final Verdict
+- **Approve**: Code is correct, safe, and follows FRR standards
+- **Request Changes**: One or more ERROR-level issues must be addressed
+
+---
+
+## Core Review Principles
+
+### Memory Safety Is Non-Negotiable
+- Every `XMALLOC`/`XCALLOC` must have a corresponding `XFREE` on all code paths
+- Check for use-after-free, double-free, and NULL dereference
+- Verify buffer bounds on all string operations
+- Look for memory leaks in error paths and early returns
+- If a function allocates memory, verify the caller frees it (or document ownership)
+
+### Routing Protocol Correctness
+- Verify state machine transitions match the relevant RFC
+- Check that timers are properly started, reset, and cancelled
+- Verify peer/neighbor lifecycle: creation, state changes, deletion
+- Look for edge cases: rapid flap, simultaneous open, graceful restart
+- Ensure route redistribution and filtering logic is correct
+- Verify that route attributes are properly propagated and not corrupted
+
+### Concurrency and Threading
+- FRR daemons use an event-driven model with `threadmaster`
+- Verify proper use of `frr_with_mutex` for shared state
+- Check that callbacks don't block the event loop
+- Verify thread-safety of any shared data structures
+- Look for TOCTOU races in file/socket operations
+
+### CLI/VTY Consistency
+- New commands must use `DEFPY` (not `DEFUN`)
+- Command help strings must be accurate and consistent
+- Verify the `no` form of configuration commands works correctly
+- Check that `show` commands have proper JSON output (`json` keyword)
+- Ensure commands are installed in the correct VTY node
+
+### JSON Output
+- Keys must be camelCased (not kebab-case, not snake_case)
+- Empty results must return `{}`, never null or missing output
+- Structure must match or be backed by a YANG model
+- Verify JSON is valid — no trailing commas, proper escaping
+- Numeric values should be numbers, not strings
+
+### Packet Parsing & Wire Format Safety (Strict Enforcement)
+
+This is a **high-priority security concern**. Code that parses network packets or protocol messages from peers is the primary attack surface for routing daemons. Apply maximum scrutiny to any code handling wire-format data.
+
+**Mandatory checks for all packet parsing code:**
+- **Bounds checking before every read**: Verify remaining buffer length (e.g., `STREAM_READABLE(s)`, `ntohs(length)`) before extracting any field
+- **Length field validation**: Length fields read from wire data MUST be validated against remaining buffer size before use as allocation sizes or loop bounds
+- **No unsafe pointer arithmetic**: Never advance a pointer into a packet buffer without first verifying the target offset is within bounds
+- **No assumptions about minimum packet size**: Always check, even for "well-known" fixed-size headers — malformed packets are the norm in security testing
+- **Integer overflow checks**: When computing sizes from wire data (e.g., `count * element_size`), check for overflow before allocation or memcpy
+
+**Applies especially to:**
+- BGP UPDATE, OPEN, NOTIFICATION, and CAPABILITY parsing (`bgpd/bgp_packet.c`, `bgpd/bgp_attr.c`, `bgpd/bgp_open.c`)
+- OSPF LSA, Hello, and DD packet parsing (`ospfd/ospf_packet.c`, `ospfd/ospf_lsa.c`)
+- IS-IS TLV and PDU parsing (`isisd/isis_tlvs.c`, `isisd/isis_pdu.c`)
+- Zebra ZAPI message parsing (`lib/zclient.c`, `zebra/zserv.c`)
+- BFD, PIM, LDP, VRRP, and any other protocol message handlers
+- Any code using `stream_get*`, `stream_put*`, `STREAM_READABLE`, or raw buffer pointer manipulation
+
+**Flag as ERROR:**
+- Missing bounds check before `stream_getl`, `stream_getw`, `stream_getc`, or equivalent
+- Using a wire-supplied length to allocate memory without upper-bound validation
+- Pointer arithmetic on packet buffers without prior length verification
+- Missing validation of TLV/attribute length fields before processing TLV body
+
+### RCU (Read-Copy-Update) Safety
+
+Per `doc/developer/rcu.rst`:
+- `rcu_read_lock()` MUST be held **continuously** while accessing RCU-protected data — do not release and re-acquire between pointer dereference steps
+- Never call `rcu_free()` or deallocate RCU-protected memory without proper RCU grace period
+- Use `atomic_load()` / `atomic_store()` for RCU pointer access (FRR does NOT use `rcu_dereference` — that's Linux kernel API)
+- Atomic list operations require `rwlock` — read lock for all accesses (read, add, remove), write lock as sequence point before deallocation
+- `struct event` callbacks are called with RCU depth of 1 — be aware of this when writing event handlers
+
+### Assert Usage (Do NOT Misuse)
+
+Per `doc/developer/logging.rst`:
+- `assert()` is for **pretty crashes only** — development hints and invariant violations that indicate bugs
+- Asserts remain enabled in production — they WILL crash the daemon
+- **NEVER** use assert for input validation, length checking, or security constraints — use ERROR-level logging and proper error handling instead
+- For unhandled internal constraint violations (mismatched pointers, NULL required fields, data corruption), use `zlog_err` or `flog_err`, NOT assert
+
+### Edge Cases to Always Check
+- What happens when the input is NULL?
+- What happens when a list/table is empty?
+- What happens on allocation failure? (XMALLOC never returns NULL, but XREALLOC can)
+- What happens during daemon shutdown/restart?
+- What happens with maximum-size inputs? (e.g., max prefix length, max AS path)
+- What happens under rapid configuration changes?
+
+---
+
+## Style Exceptions by Directory
+
+### ldpd/
+Uses **BSD coding style**, not Linux kernel style. Do not flag BSD-style formatting.
+
+### babeld/
+Uses **K&R style braces** with **4-space indents** and function return types on their own line. Do not flag these patterns.
+
+---
+
+## Topotest Coverage (Priority Check)
+
+This is a **primary review concern**. For every PR that adds or changes daemon functionality:
+
+1. **Check if the PR includes topotest additions/updates** under `tests/topotests/`
+2. **Cross-reference the changed code paths against existing topotests** — examine whether the specific daemon behavior being modified is exercised by any test topology
+3. **Evaluate coverage depth** — a test that merely starts the daemon is insufficient; tests must exercise the specific code paths being changed (e.g., if a PR changes BGP route-map handling, check that the topotest actually applies route-maps and validates the filtered output)
+4. If significant new logic is introduced with no test coverage, flag it clearly
+
+**When to flag:**
+- New features without any topotest
+- Behavior changes without updated test assertions
+- Bug fixes for complex logic without a regression test
+- PR modifies protocol state machine but no test validates the state transitions
+
+**When NOT to flag (avoid spam):**
+- Simple one-line bug fixes (e.g., off-by-one, NULL check)
+- Typo or comment corrections
+- Documentation-only changes
+- Pure refactors that don't change behavior (existing tests should still pass)
+
+**Topotest quality checks (if tests ARE included):**
+- Tests must use `pytest` framework (see `doc/developer/topotests.rst`)
+- Python test code must be formatted with `black`
+- Tests should validate specific outputs, not just "daemon didn't crash"
+- JSON output tests should use `json_cmp` for structured comparison
+
+## Documentation Checks (Smart, Non-Intrusive)
+
+Documentation flags must be **context-aware**. Spamming every PR with "update the docs" is counterproductive.
+
+### User Docs (doc/user/)
+Ask "Have the User Docs been updated?" **only when**:
+- New CLI commands are added (DEFPY/DEFUN)
+- Existing CLI command syntax changes
+- New `show` commands or JSON output fields are added
+- YANG model changes that affect user configuration
+- New daemon behavior that users need to know about
+
+### Developer Docs (doc/developer/)
+Ask "Have the Developer Docs been updated?" **only when**:
+- New internal APIs are added to `lib/`
+- Architectural changes to data structures or threading model
+- New locking patterns or event loop conventions
+- Changes to the build system or development workflow
+
+### NEVER ask for doc updates on:
+- Standard, simple bug fixes
+- Minor refactors that follow existing patterns
+- Internal variable renames or code cleanup
+- Changes that don't alter any user-visible or developer-visible behavior
+
+---
+
+## What Makes a Good FRR Patch
+
+1. **Does one thing well** — single logical change per commit
+2. **Explains why** — commit message describes the problem and solution
+3. **Is tested** — includes or references automated tests for significant changes
+4. **Is safe** — no memory leaks, no crashes, no undefined behavior
+5. **Is backwards compatible** — or has a proper deprecation path
+6. **Is documented** — user-facing changes have doc/user/ updates
+7. **Passes CI** — all checks green, no new static analysis warnings

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -141,16 +141,28 @@ int routing_control_plane_protocols_name_validate(
 
 /* xpath macros */
 /* route-list */
-#define FRR_STATIC_ROUTE_INFO_KEY_XPATH                                                            \
-	"/frr-routing:routing/control-plane-protocols/"                                            \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                  \
-	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"             \
+#define FRR_STATIC_ROUTE_INFO_KEY_XPATH                                                           \
+	"/frr-routing:routing/control-plane-protocols/"                                           \
+	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                 \
+	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"            \
+	"path-list[table-id='%u'][distance='%u'][metric='%u']"
+
+#define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                                               \
+	"/frr-routing:routing/control-plane-protocols/"                                           \
+	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                 \
+	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"            \
+	"path-list[table-id='%u'][metric='%u']"
+
+#define FRR_STATIC_ROUTE_INFO_KEY_NO_METRIC_XPATH                                                 \
+	"/frr-routing:routing/control-plane-protocols/"                                           \
+	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                 \
+	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"            \
 	"path-list[table-id='%u'][distance='%u']"
 
-#define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                                                \
-	"/frr-routing:routing/control-plane-protocols/"                                            \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                  \
-	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"             \
+#define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_METRIC_XPATH                                        \
+	"/frr-routing:routing/control-plane-protocols/"                                           \
+	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                 \
+	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"            \
 	"path-list[table-id='%u']"
 
 
@@ -187,6 +199,16 @@ int routing_control_plane_protocols_name_validate(
 /* route-list/frr-nexthops */
 #define FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH                               \
 	FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                            \
+	FRR_STATIC_ROUTE_NH_KEY_XPATH
+
+/* route-list/frr-nexthops */
+#define FRR_DEL_S_ROUTE_NH_KEY_NO_METRIC_XPATH                                                    \
+	FRR_STATIC_ROUTE_INFO_KEY_NO_METRIC_XPATH                                                 \
+	FRR_STATIC_ROUTE_NH_KEY_XPATH
+
+/* route-list/frr-nexthops */
+#define FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_METRIC_XPATH                                           \
+	FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_METRIC_XPATH                                        \
 	FRR_STATIC_ROUTE_NH_KEY_XPATH
 
 /* srv6 */

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -31,6 +31,7 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	const struct lyd_node *vrf_dnode;
 	const char *vrf;
 	uint8_t distance;
+	uint32_t metric;
 	uint32_t table_id;
 
 	switch (args->event) {
@@ -60,8 +61,9 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	case NB_EV_APPLY:
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		distance = yang_dnode_get_uint8(args->dnode, "distance");
+		metric = yang_dnode_get_uint32(args->dnode, "metric");
 		table_id = yang_dnode_get_uint32(args->dnode, "table-id");
-		pn = static_add_path(rn, table_id, distance);
+		pn = static_add_path(rn, table_id, distance, metric);
 		nb_running_set_entry(args->dnode, pn);
 	}
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -141,8 +141,8 @@ bool static_add_nexthop_validate(const char *nh_vrf_name,
 	return true;
 }
 
-struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
-				    uint8_t distance)
+struct static_path *static_add_path(struct route_node *rn, uint32_t table_id, uint8_t distance,
+				    uint32_t metric)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
@@ -154,6 +154,7 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 
 	pn->rn = rn;
 	pn->distance = distance;
+	pn->metric = metric;
 	pn->table_id = table_id;
 	static_nexthop_list_init(&(pn->nexthop_list));
 

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -93,6 +93,8 @@ struct static_path {
 	struct static_path_list_item list;
 	/* Administrative distance. */
 	uint8_t distance;
+	/* Route metric. */
+	uint32_t metric;
 	/* Tag */
 	route_tag_t tag;
 	/* Table-id */
@@ -225,8 +227,8 @@ extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 					   struct static_vrf *svrf);
 extern void static_del_route(struct route_node *rn);
 
-extern struct static_path *static_add_path(struct route_node *rn,
-					   uint32_t table_id, uint8_t distance);
+extern struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
+					   uint8_t distance, uint32_t metric);
 extern void static_del_path(struct static_path *pn);
 
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -55,6 +55,7 @@ struct static_route_args {
 	const char *flag;
 	const char *tag;
 	const char *distance;
+	const char *metric;
 	const char *label;
 	const char *table;
 	const char *color;
@@ -93,6 +94,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	const char *buf_gate_str;
 	struct ipaddr gate_ip;
 	uint8_t distance = ZEBRA_STATIC_DISTANCE_DEFAULT;
+	uint32_t metric = 0;
 	route_tag_t tag = 0;
 	uint32_t table_id = 0;
 	const struct lyd_node *dnode;
@@ -186,6 +188,10 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	if (args->distance)
 		distance = strtol(args->distance, NULL, 10);
 
+	/* Metric */
+	if (args->metric)
+		metric = strtol(args->metric, NULL, 10);
+
 	/* tag */
 	if (args->tag)
 		tag = strtoul(args->tag, NULL, 10);
@@ -196,14 +202,15 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 
 	static_get_nh_type(type, buf_nh_type, sizeof(buf_nh_type));
 	if (!args->delete) {
-		snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH,
-			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
-			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, buf_nh_type,
-			 args->nexthop_vrf, buf_gate_str, args->interface_name);
+		snprintf(ab_xpath, sizeof(ab_xpath),
+			 FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_METRIC_XPATH, "frr-staticd:staticd",
+			 "staticd", args->vrf, buf_prefix, buf_src_prefix,
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+			 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
 
 		/*
 		 * If there's already the same nexthop but with a different
-		 * distance, then remove it for the replacement.
+		 * distance and/or metric, then remove it for the replacement.
 		 */
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (dnode) {
@@ -218,7 +225,8 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		/* route + path processing */
 		snprintf(xpath_prefix, sizeof(xpath_prefix), FRR_STATIC_ROUTE_INFO_KEY_XPATH,
 			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
-			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance);
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance,
+			 metric);
 
 		nb_cli_enqueue_change(vty, xpath_prefix, NB_OP_CREATE, NULL);
 
@@ -427,18 +435,35 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		if (orig_seg)
 			XFREE(MTYPE_TMP, orig_seg);
 	} else {
-		if (args->distance)
+		if (args->distance && args->metric)
 			snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_XPATH,
 				 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix,
-				 buf_src_prefix, yang_afi_safi_value2identity(args->afi, args->safi),
-				 table_id, distance, buf_nh_type, args->nexthop_vrf, buf_gate_str,
+				 buf_src_prefix,
+				 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+				 distance, metric, buf_nh_type, args->nexthop_vrf, buf_gate_str,
 				 args->interface_name);
-		else
+		else if (args->metric)
 			snprintf(ab_xpath, sizeof(ab_xpath),
 				 FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH, "frr-staticd:staticd",
 				 "staticd", args->vrf, buf_prefix, buf_src_prefix,
 				 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
-				 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
+				 metric, buf_nh_type, args->nexthop_vrf, buf_gate_str,
+				 args->interface_name);
+		else if (args->distance)
+			snprintf(ab_xpath, sizeof(ab_xpath),
+				 FRR_DEL_S_ROUTE_NH_KEY_NO_METRIC_XPATH, "frr-staticd:staticd",
+				 "staticd", args->vrf, buf_prefix, buf_src_prefix,
+				 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+				 distance, buf_nh_type, args->nexthop_vrf, buf_gate_str,
+				 args->interface_name);
+		else
+			snprintf(ab_xpath, sizeof(ab_xpath),
+				 FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_METRIC_XPATH,
+				 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix,
+				 buf_src_prefix,
+				 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+				 buf_nh_type, args->nexthop_vrf, buf_gate_str,
+				 args->interface_name);
 
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (!dnode) {
@@ -489,6 +514,7 @@ DEFPY_YANG (ip_mroute_dist,
        ip_mroute_dist_cmd,
        "[no] ip mroute A.B.C.D/M$prefix <A.B.C.D$gate|INTERFACE$ifname> [{"
        "(1-255)$distance"
+       "|metric (0-4294967295)"
        "|bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}]"
        "}]",
        NO_STR
@@ -498,6 +524,8 @@ DEFPY_YANG (ip_mroute_dist,
        "Nexthop address\n"
        "Nexthop interface name\n"
        "Distance\n"
+       "Set metric for this route\n"
+       "Metric value for this route\n"
        BFD_INTEGRATION_STR
        BFD_INTEGRATION_MULTI_HOP_STR
        BFD_INTEGRATION_SOURCE_STR
@@ -513,6 +541,7 @@ DEFPY_YANG (ip_mroute_dist,
 		.gateway = gate_str,
 		.interface_name = ifname,
 		.distance = distance_str,
+		.metric = metric_str,
 		.bfd = !!bfd,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
@@ -531,6 +560,7 @@ DEFPY_YANG(ip_route_blackhole,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+          |metric (0-4294967295)                                              \
 	  |vrf NAME                                                           \
 	  |label WORD                                                         \
           |table (1-4294967295)                                               \
@@ -545,6 +575,8 @@ DEFPY_YANG(ip_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -559,6 +591,7 @@ DEFPY_YANG(ip_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -575,6 +608,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+          |metric (0-4294967295)                                              \
 	  |label WORD                                                         \
 	  |table (1-4294967295)                                               \
           }]",
@@ -588,6 +622,8 @@ DEFPY_YANG(ip_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -601,6 +637,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -625,6 +662,7 @@ DEFPY_YANG(ip_route_address_interface,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |vrf NAME                                    \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
@@ -647,6 +685,8 @@ DEFPY_YANG(ip_route_address_interface,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -679,6 +719,7 @@ DEFPY_YANG(ip_route_address_interface,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -706,6 +747,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
 	  |nexthop-vrf NAME                            \
@@ -727,6 +769,8 @@ DEFPY_YANG(ip_route_address_interface_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -758,6 +802,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -784,6 +829,7 @@ DEFPY_YANG(ip_route,
 	[{                                             	   \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |vrf NAME                                        \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
@@ -805,6 +851,8 @@ DEFPY_YANG(ip_route,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -836,6 +884,7 @@ DEFPY_YANG(ip_route,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -861,6 +910,7 @@ DEFPY_YANG(ip_route_vrf,
 	[{                                                 \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
 	  |nexthop-vrf NAME                                \
@@ -881,6 +931,8 @@ DEFPY_YANG(ip_route_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -911,6 +963,7 @@ DEFPY_YANG(ip_route_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -935,6 +988,7 @@ DEFPY_YANG(ipv6_route_blackhole,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
             |table (1-4294967295)                          \
@@ -950,6 +1004,8 @@ DEFPY_YANG(ipv6_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -964,6 +1020,7 @@ DEFPY_YANG(ipv6_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -979,6 +1036,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
             |table (1-4294967295)                          \
           }]",
@@ -993,6 +1051,8 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Set metric for this route\n"
+      "Metric value for this route\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -1006,6 +1066,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -1028,6 +1089,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1048,7 +1110,10 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this prefix\n"
+	   "Metric value for this prefix\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1074,6 +1139,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1100,6 +1166,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1119,7 +1186,10 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this prefix\n"
+	   "Metric value for this prefix\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1145,6 +1215,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1169,6 +1240,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1188,7 +1260,10 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this prefix\n"
+	   "Metric value for this prefix\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1213,6 +1288,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1237,6 +1313,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1255,7 +1332,10 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this prefix\n"
+	   "Metric value for this prefix\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1280,6 +1360,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1587,6 +1668,7 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	enum static_blackhole_type bh_type;
 	uint32_t tag;
 	uint8_t distance;
+	uint32_t metric;
 	struct mpls_label_iter iter;
 	struct srv6_seg_iter seg_iter;
 	enum srv6_headend_behavior srv6_encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
@@ -1662,6 +1744,10 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	distance = yang_dnode_get_uint8(path, "distance");
 	if (distance != ZEBRA_STATIC_DISTANCE_DEFAULT || show_defaults)
 		vty_out(vty, " %" PRIu8, distance);
+
+	metric = yang_dnode_get_uint32(path, "metric");
+	if (metric || show_defaults)
+		vty_out(vty, " metric %" PRIu32, metric);
 
 	iter.vty = vty;
 	iter.first = true;
@@ -1833,6 +1919,7 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 {
 	uint32_t table_id1, table_id2;
 	uint8_t distance1, distance2;
+	uint32_t metric1, metric2;
 
 	table_id1 = yang_dnode_get_uint32(dnode1, "table-id");
 	table_id2 = yang_dnode_get_uint32(dnode2, "table-id");
@@ -1843,7 +1930,13 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 	distance1 = yang_dnode_get_uint8(dnode1, "distance");
 	distance2 = yang_dnode_get_uint8(dnode2, "distance");
 
-	return (int)distance1 - (int)distance2;
+	if (distance1 != distance2)
+		return (int)distance1 - (int)distance2;
+
+	metric1 = yang_dnode_get_uint32(dnode1, "metric");
+	metric2 = yang_dnode_get_uint32(dnode2, "metric");
+
+	return (int)metric1 - (int)metric2;
 }
 
 static void static_segment_routing_cli_show(struct vty *vty, const struct lyd_node *dnode,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -441,6 +441,10 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);
 		api.distance = pn->distance;
 	}
+	if (pn->metric) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_METRIC);
+		api.metric = pn->metric;
+	}
 	if (pn->tag) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_TAG);
 		api.tag = pn->tag;

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -444,7 +444,7 @@ void grpc_client_run_test(void)
 		snprintf(xpath_buf + slen, sizeof(xpath_buf) - slen,
 			 "[prefix='13.0.%d.0/24']"
 			 "[afi-safi='frr-routing:ipv4-unicast']/"
-			 "path-list[table-id='0'][distance='1']/"
+			 "path-list[table-id='0'][distance='1'][metric='0']/"
 			 "frr-nexthops/nexthop[nh-type='blackhole']"
 			 "[vrf='default'][gateway=''][interface='(null)']",
 			 i);
@@ -584,6 +584,7 @@ const char *json_expect1 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -638,6 +639,7 @@ const char *json_loadconf1 = R"NONCE(
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "frr-nexthops": {
                       "nexthop": [
                         {
@@ -683,6 +685,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -706,6 +709,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -729,6 +733,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -752,6 +757,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -775,6 +781,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -828,6 +835,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -851,6 +859,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -874,6 +883,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -897,6 +907,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -920,6 +931,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -943,6 +955,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -180,7 +180,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -193,7 +193,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -250,7 +250,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -263,7 +263,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
                 "mgmt commit apply",
             ]
         }
@@ -303,7 +303,7 @@ def test_mgmt_commit_abort(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit abort",
             ]
         }
@@ -355,7 +355,7 @@ def test_mgmt_delete_config(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -662,7 +662,7 @@ def test_mgmt_chaos_stop_start_frr(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -738,7 +738,7 @@ def test_mgmt_chaos_kill_daemon(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }

--- a/tests/topotests/static_metrics/r1/frr.conf
+++ b/tests/topotests/static_metrics/r1/frr.conf
@@ -1,0 +1,108 @@
+interface r1-eth0
+ ip address 192.168.1.1/24
+ ipv6 address fe80:1::1/64
+exit
+
+! Standard route
+ip route 10.0.0.1/32 192.168.1.2
+! Route with explicit metric
+ip route 10.0.0.2/32 192.168.1.2 metric 1
+! Route with explicit metric, to be replaced
+ip route 10.0.0.3/32 192.168.1.2 metric 1
+! Replacement route with new metric
+ip route 10.0.0.3/32 192.168.1.2 metric 2
+! Interface/null/blackhole/reject routes with explicit metric
+ip route 10.0.0.4/32 r1-eth0 metric 1
+ip route 10.0.0.5/32 null0 metric 1
+ip route 10.0.0.6/32 blackhole metric 1
+ip route 10.0.0.7/32 reject metric 1
+ip route 10.0.0.8/32 192.168.1.2 r1-eth0 metric 1
+
+! Route with explicit distance
+ip route 10.0.1.1/32 192.168.1.2 5
+! Route with explicit distance, to be replaced
+ip route 10.0.1.2/32 192.168.1.2 5
+! Replacement route with new distance
+ip route 10.0.1.2/32 192.168.1.2 6
+! Interface/null/blackhole/reject routes with explicit distance
+ip route 10.0.1.3/32 r1-eth0 5
+ip route 10.0.1.4/32 null0 5
+ip route 10.0.1.5/32 blackhole 5
+ip route 10.0.1.6/32 reject 5
+ip route 10.0.1.7/32 192.168.1.2 r1-eth0 5
+
+! Route with explicit distance+metric
+ip route 10.0.2.1/32 192.168.1.2 5 metric 1
+! Route with explicit distance+metric, to be replaced
+ip route 10.0.2.2/32 192.168.1.2 5 metric 1
+! Replacement route with new distance+metric
+ip route 10.0.2.2/32 192.168.1.2 6 metric 2
+! Interface/null/blackhole/reject routes with explicit distance+metric
+ip route 10.0.2.3/32 r1-eth0 5 metric 1
+ip route 10.0.2.4/32 null0 5 metric 1
+ip route 10.0.2.5/32 blackhole 5 metric 1
+ip route 10.0.2.6/32 reject 5 metric 1
+ip route 10.0.2.7/32 192.168.1.2 r1-eth0 5 metric 1
+
+! Routes with metric for (successful) delete tests
+ip route 10.0.3.1/32 192.168.1.2 7 metric 10
+ip route 10.0.3.2/32 192.168.1.2 7 metric 10
+ip route 10.0.3.3/32 192.168.1.2 7 metric 10
+ip route 10.0.3.4/32 192.168.1.2 7 metric 10
+ip route 10.0.3.5/32 r1-eth0 7 metric 10
+ip route 10.0.3.6/32 blackhole 7 metric 10
+ip route 10.0.3.7/32 192.168.1.2 r1-eth0 7 metric 10
+! Route with metric for (unsuccessful) delete test
+ip route 10.0.3.8/32 192.168.1.2 7 metric 10
+
+! Standard route
+ipv6 route 2001:db8:0:1::/64 fe80:1::2
+! Route with explicit metric
+ipv6 route 2001:db8:0:2::/64 fe80:1::2 metric 1
+! Route with explicit metric, to be replaced
+ipv6 route 2001:db8:0:3::/64 fe80:1::2 metric 1
+! Replacement route with new metric
+ipv6 route 2001:db8:0:3::/64 fe80:1::2 metric 2
+! Interface/null/blackhole/reject routes with explicit metric
+ipv6 route 2001:db8:0:4::/64 r1-eth0 metric 1
+ipv6 route 2001:db8:0:5::/64 null0 metric 1
+ipv6 route 2001:db8:0:6::/64 blackhole metric 1
+ipv6 route 2001:db8:0:7::/64 reject metric 1
+ipv6 route 2001:db8:0:8::/64 fe80:1::2 r1-eth0 metric 1
+
+! Route with explicit distance
+ipv6 route 2001:db8:1:1::/64 fe80:1::2 5
+! Route with explicit distance, to be replaced
+ipv6 route 2001:db8:1:2::/64 fe80:1::2 5
+! Replacement route with new distance
+ipv6 route 2001:db8:1:2::/64 fe80:1::2 6
+! Interface/null/blackhole/reject routes with explicit distance
+ipv6 route 2001:db8:1:3::/64 r1-eth0 5
+ipv6 route 2001:db8:1:4::/64 null0 5
+ipv6 route 2001:db8:1:5::/64 blackhole 5
+ipv6 route 2001:db8:1:6::/64 reject 5
+ipv6 route 2001:db8:1:7::/64 fe80:1::2 r1-eth0 5
+
+! Route with explicit distance+metric
+ipv6 route 2001:db8:2:1::/64 fe80:1::2 5 metric 1
+! Route with explicit distance+metric, to be replaced
+ipv6 route 2001:db8:2:2::/64 fe80:1::2 5 metric 1
+! Replacement route with new distance+metric
+ipv6 route 2001:db8:2:2::/64 fe80:1::2 6 metric 2
+! Interface/null/blackhole/reject routes with explicit distance+metric
+ipv6 route 2001:db8:2:3::/64 r1-eth0 5 metric 1
+ipv6 route 2001:db8:2:4::/64 null0 5 metric 1
+ipv6 route 2001:db8:2:5::/64 blackhole 5 metric 1
+ipv6 route 2001:db8:2:6::/64 reject 5 metric 1
+ipv6 route 2001:db8:2:7::/64 fe80:1::2 r1-eth0 5 metric 1
+
+! Routes with metric for (successful) delete tests
+ipv6 route 2001:db8:3:1::/64 fe80:1::2 7 metric 10
+ipv6 route 2001:db8:3:2::/64 fe80:1::2 7 metric 10
+ipv6 route 2001:db8:3:3::/64 fe80:1::2 7 metric 10
+ipv6 route 2001:db8:3:4::/64 fe80:1::2 7 metric 10
+ipv6 route 2001:db8:3:5::/64 r1-eth0 7 metric 10
+ipv6 route 2001:db8:3:6::/64 blackhole 7 metric 10
+ipv6 route 2001:db8:3:7::/64 fe80:1::2 r1-eth0 7 metric 10
+! Route with metric for (unsuccessful) delete test
+ipv6 route 2001:db8:3:8::/64 fe80:1::2 7 metric 10

--- a/tests/topotests/static_metrics/r1/static_ipv4_after_del.json
+++ b/tests/topotests/static_metrics/r1/static_ipv4_after_del.json
@@ -1,0 +1,170 @@
+{
+  "10.0.0.1/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 0
+    }
+  ],
+  "10.0.0.2/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.3/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 2
+    }
+  ],
+  "10.0.0.4/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.5/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.6/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.7/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.8/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.1.1/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.2/32": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 0
+    }
+  ],
+  "10.0.1.3/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.4/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.5/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.6/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.7/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.2.1/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.2/32": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 2
+    }
+  ],
+  "10.0.2.3/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.4/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.5/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.6/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.7/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.3.1/32": null,
+  "10.0.3.2/32": null,
+  "10.0.3.3/32": null,
+  "10.0.3.4/32": null,
+  "10.0.3.5/32": null,
+  "10.0.3.6/32": null,
+  "10.0.3.7/32": null,
+  "10.0.3.8/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ]
+}

--- a/tests/topotests/static_metrics/r1/static_ipv4_initial.json
+++ b/tests/topotests/static_metrics/r1/static_ipv4_initial.json
@@ -1,0 +1,212 @@
+{
+  "10.0.0.1/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 0
+    }
+  ],
+  "10.0.0.2/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.3/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 2
+    }
+  ],
+  "10.0.0.4/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.5/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.6/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.7/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.0.8/32": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "10.0.1.1/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.2/32": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 0
+    }
+  ],
+  "10.0.1.3/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.4/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.5/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.6/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.1.7/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "10.0.2.1/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.2/32": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 2
+    }
+  ],
+  "10.0.2.3/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.4/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.5/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.6/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.2.7/32": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "10.0.3.1/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.2/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.3/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.4/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.5/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.6/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.7/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "10.0.3.8/32": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ]
+}

--- a/tests/topotests/static_metrics/r1/static_ipv6_after_del.json
+++ b/tests/topotests/static_metrics/r1/static_ipv6_after_del.json
@@ -1,0 +1,170 @@
+{
+  "2001:db8:0:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 0
+    }
+  ],
+  "2001:db8:0:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 2
+    }
+  ],
+  "2001:db8:0:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:8::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:1:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:2:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 2
+    }
+  ],
+  "2001:db8:2:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:3:1::/64": null,
+  "2001:db8:3:2::/64": null,
+  "2001:db8:3:3::/64": null,
+  "2001:db8:3:4::/64": null,
+  "2001:db8:3:5::/64": null,
+  "2001:db8:3:6::/64": null,
+  "2001:db8:3:7::/64": null,
+  "2001:db8:3:8::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ]
+}

--- a/tests/topotests/static_metrics/r1/static_ipv6_initial.json
+++ b/tests/topotests/static_metrics/r1/static_ipv6_initial.json
@@ -1,0 +1,212 @@
+{
+  "2001:db8:0:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 0
+    }
+  ],
+  "2001:db8:0:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 2
+    }
+  ],
+  "2001:db8:0:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:0:8::/64": [
+    {
+      "protocol": "static",
+      "distance": 1,
+      "metric": 1
+    }
+  ],
+  "2001:db8:1:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:1:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 0
+    }
+  ],
+  "2001:db8:2:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 6,
+      "metric": 2
+    }
+  ],
+  "2001:db8:2:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:2:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 5,
+      "metric": 1
+    }
+  ],
+  "2001:db8:3:1::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:2::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:3::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:4::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:5::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:6::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:7::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ],
+  "2001:db8:3:8::/64": [
+    {
+      "protocol": "static",
+      "distance": 7,
+      "metric": 10
+    }
+  ]
+}

--- a/tests/topotests/static_metrics/test_static_metrics.py
+++ b/tests/topotests/static_metrics/test_static_metrics.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2025 by
+# Donatas Abraitis <donatas@opensourcerouting.org>
+# Copyright (c) 2026 by Martin Buck
+#
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.staticd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_static_metrics():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check_static_routes(router, ip, reffile):
+        reffile_abs = os.path.join(CWD, reffile)
+        expected = json.loads(open(reffile_abs).read())
+
+        test_func = functools.partial(
+            topotest.router_json_cmp,
+            router,
+            f"show {ip} route json",
+            expected,
+        )
+        _, res = topotest.run_and_expect(test_func, None, count=15, wait=1)
+        assertmsg = f"Static routes on R1 don't match expected in {reffile}"
+        assert res is None, assertmsg
+
+    _check_static_routes(r1, "ip", "r1/static_ipv4_initial.json")
+    _check_static_routes(r1, "ipv6", "r1/static_ipv6_initial.json")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        ! Expecting success
+        no ip route 10.0.3.1/32 192.168.1.2
+        no ip route 10.0.3.2/32 192.168.1.2 7
+        no ip route 10.0.3.3/32 192.168.1.2 metric 10
+        no ip route 10.0.3.4/32 192.168.1.2 7 metric 10
+        no ip route 10.0.3.5/32 r1-eth0 7 metric 10
+        no ip route 10.0.3.6/32 blackhole 7 metric 10
+        no ip route 10.0.3.7/32 192.168.1.2 r1-eth0 7 metric 10
+        ! Expecting failure
+        no ip route 10.0.3.8/32 192.168.1.2 metric 20
+        no ip route 10.0.3.8/32 192.168.1.2 8
+        no ip route 10.0.3.8/32 192.168.1.2 8 metric 20
+        ! Expecting success
+        no ipv6 route 2001:db8:3:1::/64 fe80:1::2
+        no ipv6 route 2001:db8:3:2::/64 fe80:1::2 7
+        no ipv6 route 2001:db8:3:3::/64 fe80:1::2 metric 10
+        no ipv6 route 2001:db8:3:4::/64 fe80:1::2 7 metric 10
+        no ipv6 route 2001:db8:3:5::/64 r1-eth0 7 metric 10
+        no ipv6 route 2001:db8:3:6::/64 blackhole 7 metric 10
+        no ipv6 route 2001:db8:3:7::/64 fe80:1::2 r1-eth0 7 metric 10
+        ! Expecting failure
+        no ipv6 route 2001:db8:3:8::/64 fe80:1::2 metric 20
+        no ipv6 route 2001:db8:3:8::/64 fe80:1::2 8
+        no ipv6 route 2001:db8:3:8::/64 fe80:1::2 8 metric 20
+        """
+    )
+
+    _check_static_routes(r1, "ip", "r1/static_ipv4_after_del.json")
+    _check_static_routes(r1, "ipv6", "r1/static_ipv6_after_del.json")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -85,7 +85,7 @@ module frr-staticd {
     description
       "Grouping for staticd prefix attributes.";
     list path-list {
-      key "table-id distance";
+      key "table-id distance metric";
       description
         "List of paths associated with a staticd prefix.";
       leaf table-id {
@@ -98,6 +98,12 @@ module frr-staticd {
         type frr-rt:administrative-distance;
         description
           "Admin distance associated with this route.";
+      }
+
+      leaf metric {
+        type uint32;
+        description
+          "Metric associated with this route.";
       }
 
       leaf tag {


### PR DESCRIPTION
Add support for the "metric" keyword to "ip{,v6} route ..." to be able to specify nonzero metrics for static routes. This is in addition to the (already supported) configurable administrative distance. Useful if static routes are redistributed into other routing protocols while retaining the metric or to arbitrate between static and dynamic routes.

Note 1: I don't know too much about YANG but had to modify staticd's YANG model to store the new metric. Reviewers might want to have a very close look at my changes to `frr-staticd.yang`.
Note 2: I added the new `metric` keyword to all kinds of static route commands for consistency reasons, including blackhole routes and mroutes. Does that make sense for those route types?