### PR TITLE
staticd: add metric as path-list key for static routes

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -27,21 +27,21 @@ Static Route Commands
 Static routing is a very fundamental feature of routing technology. It defines
 a static prefix and gateway, with several possible forms.
 
-.. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [tag TAG] [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [tag TAG] [DISTANCE] [metric METRIC] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [tag TAG] [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
    NETWORK is destination prefix with a valid v4 or v6 network based upon
    initial form of the command.
@@ -61,6 +61,16 @@ a static prefix and gateway, with several possible forms.
    Alternatively, the gateway can be specified as ``Null0`` or ``blackhole`` to create a blackhole
    route that drops all traffic. It can also be specified as ``reject`` to create an unreachable
    route that rejects traffic with ICMP "Destination Unreachable" messages.
+
+   TAG is an optional 32-bit unsigned integer (1–4294967295) that marks the
+   route entry in the RIB. See :ref:`static-route-tag` for details and
+   limitations.
+
+   DISTANCE is an optional administrative distance (1–255; default 1). See
+   :ref:`static-route-distance-metric` for details.
+
+   METRIC is an optional route metric (0–4294967295; default 0). See
+   :ref:`static-route-distance-metric` for details.
 
    WEIGHT is an optional parameter that specifies the weight attributed to a
    nexthop when multiple nexthops are configured for the same static route. The
@@ -164,6 +174,131 @@ but this time, the route command will apply to the VRF.
    vrf r1-cust1
     ip route 10.0.0.0/24 10.0.0.2
    exit-vrf
+
+
+.. _static-route-distance-metric:
+
+Administrative Distance and Metric
+===================================
+
+Static routes are grouped internally by ``(table-id, distance, metric)``.
+Nexthops that share the same tuple belong to the same *path group* and are
+installed in the RIB together as an ECMP set.  Nexthops in different path
+groups for the same prefix are independent: all path groups are present in
+the RIB, but only the group with the lowest distance (and, for the same
+distance, the lowest metric) is selected at any time.
+
+**ECMP** — Multiple nexthops with the same ``(distance, metric)`` form an
+equal-cost multipath group and are active in the RIB together:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2
+   ip route 10.0.0.0/8 10.0.0.3
+
+Both nexthops share ``(distance=1, metric=0)`` and are active in the RIB as ECMP.
+
+**Floating static routes** — Nexthops with different ``(distance, metric)`` tuples
+form separate path groups.  All groups are present in the RIB; the group with
+the best preference (lowest distance, then lowest metric) is selected.  A
+lower-preference group is promoted when the higher-preference group becomes
+unreachable.
+
+Floating by distance:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2
+   ip route 10.0.0.0/8 10.0.0.3 200
+
+``10.0.0.2`` is the primary (distance 1); ``10.0.0.3`` is the fallback
+(distance 200), promoted only when ``10.0.0.2`` is gone.
+
+Floating by metric (same distance, different metric):
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 metric 100
+   ip route 10.0.0.0/8 10.0.0.3 metric 200
+
+``10.0.0.2`` is the primary (metric 100); ``10.0.0.3`` is the fallback
+(metric 200), promoted only when ``10.0.0.2`` is gone.
+
+**Nexthop uniqueness and automatic move** — A given nexthop (identified by
+its forwarding information: type, gateway address, and interface) may appear
+in at most one path group under a prefix at a time.  If a nexthop is
+reconfigured with a new distance or metric, FRR automatically removes it from
+the old path group and installs it in the new one:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 10
+   ! Reconfigure with a new distance — old entry is removed automatically:
+   ip route 10.0.0.0/8 10.0.0.2 20
+
+After the second command there is exactly one path group for ``10.0.0.2`` at
+distance 20; no stale distance-10 entry remains.  The same applies when
+metric is changed.
+
+**Removing routes** — FRR identifies the nexthop to remove by its nexthop
+identity (gateway address, interface, or blackhole type) and ignores the
+distance and metric arguments.  Because a given nexthop can appear in at most
+one path group for a prefix, the search is always unambiguous:
+
+.. code-block:: frr
+
+   no ip route 10.0.0.0/8 10.0.0.2
+   no ip route 10.0.0.0/8 10.0.0.2 10
+   no ip route 10.0.0.0/8 10.0.0.2 10 metric 50
+
+All three commands above remove the same nexthop ``10.0.0.2``, regardless of
+which distance or metric it was configured with.
+
+
+.. _static-route-tag:
+
+Route Tag
+=========
+
+TAG is a 32-bit unsigned integer (1–4294967295) that marks a route entry in
+the RIB.  It can be matched by routing policy (route-maps, prefix-lists) to
+filter or modify routes based on their tag value.
+
+The tag is a per-path-group attribute: it is shared by all nexthops in a path
+group and carried into the RIB.  Unlike distance and metric, tag is **not**
+part of the path group identity — two nexthops with the same ``(distance,
+metric)`` always belong to the same path group regardless of their configured
+tags.
+
+**Per-path-group tag** — Assigning a distinct tag to each path group lets
+routing policy distinguish primary from backup routes:
+
+.. code-block:: frr
+
+   ip route 10.0.0.0/8 10.0.0.2 tag 100 10
+   ip route 10.0.0.0/8 10.0.0.3 tag 200 20
+
+``10.0.0.2`` (distance 10) carries tag 100 and ``10.0.0.3`` (distance 20)
+carries tag 200.  Both tags are visible in the RIB simultaneously.
+
+.. note::
+
+   **Limitation — same (distance, metric), different tag:** because tag is
+   not part of the path group key, two nexthops with the same ``(distance,
+   metric)`` belong to the same path group regardless of their tags.  When
+   different tags are configured for nexthops in the same path group, the
+   last-configured value applies to the entire group and the earlier value is
+   silently overwritten:
+
+   .. code-block:: frr
+
+      ip route 10.0.0.0/8 10.0.0.2 tag 100 10
+      ip route 10.0.0.0/8 10.0.0.3 tag 200 10
+
+   Both nexthops are grouped at distance 10 and the path tag becomes 200
+   (the last value configured).  ``show running-config`` reflects only the
+   final value.  To assign independent tags to nexthops, use different
+   distances or metrics.
 
 
 SR-TE Route Commands

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -141,11 +141,11 @@ int routing_control_plane_protocols_name_validate(
 
 /* xpath macros */
 /* route-list */
-#define FRR_STATIC_ROUTE_INFO_KEY_XPATH                                                            \
-	"/frr-routing:routing/control-plane-protocols/"                                            \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                  \
-	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"             \
-	"path-list[table-id='%u'][distance='%u']"
+#define FRR_STATIC_ROUTE_INFO_KEY_XPATH                                                           \
+	"/frr-routing:routing/control-plane-protocols/"                                           \
+	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"                                 \
+	"frr-staticd:staticd/route-list[prefix='%s'][src-prefix='%s'][afi-safi='%s']/"            \
+	"path-list[table-id='%u'][distance='%u'][metric='%u']"
 
 #define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                                                \
 	"/frr-routing:routing/control-plane-protocols/"                                            \

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -32,6 +32,7 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	const char *vrf;
 	uint8_t distance;
 	uint32_t table_id;
+	uint32_t metric;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -61,7 +62,8 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		distance = yang_dnode_get_uint8(args->dnode, "distance");
 		table_id = yang_dnode_get_uint32(args->dnode, "table-id");
-		pn = static_add_path(rn, table_id, distance);
+		metric = yang_dnode_get_uint32(args->dnode, "metric");
+		pn = static_add_path(rn, table_id, distance, metric);
 		nb_running_set_entry(args->dnode, pn);
 	}
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -141,8 +141,8 @@ bool static_add_nexthop_validate(const char *nh_vrf_name,
 	return true;
 }
 
-struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
-				    uint8_t distance)
+struct static_path *static_add_path(struct route_node *rn, uint32_t table_id, uint8_t distance,
+				    uint32_t metric)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
@@ -154,6 +154,7 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 
 	pn->rn = rn;
 	pn->distance = distance;
+	pn->metric = metric;
 	pn->table_id = table_id;
 	static_nexthop_list_init(&(pn->nexthop_list));
 

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -77,6 +77,48 @@ enum static_install_states {
 PREDECL_DLIST(static_path_list);
 PREDECL_DLIST(static_nexthop_list);
 
+/*
+ * Data model: prefix -> path-list -> nexthop-list
+ *
+ * Each prefix (route_node) has one static_route_info attached as rn->info.
+ * Under it is a list of static_path objects, each uniquely identified by
+ * (table-id, distance, metric).  Under each path is a list of static_nexthop
+ * objects that share those attributes.  Tag is a per-path attribute (not a key).
+ *
+ *   prefix (route_node / static_route_info)
+ *     |
+ *     +-- static_path  [table-id=0, distance=10, metric=0]  tag=100
+ *     |     +-- static_nexthop  NH1   \
+ *     |     +-- static_nexthop  NH2   /  ECMP group (same distance, metric)
+ *     |
+ *     +-- static_path  [table-id=0, distance=10, metric=20]  tag=200
+ *     |     +-- static_nexthop  NH3       metric-based floating static
+ *     |
+ *     +-- static_path  [table-id=0, distance=20, metric=0]  tag=300
+ *           +-- static_nexthop  NH4       AD-based floating static (standby)
+ *
+ * Route preference: AD and metric together determine which path is active in
+ * the RIB.  AD is the primary preference key; for the same AD, metric is
+ * the secondary key.  All paths are sent to zebra; zebra stores each
+ * (AD, metric) combination as a separate route_entry and rib_choose_best()
+ * selects the one with the lowest AD (and lowest metric for the same AD)
+ * for the RIB.  A path with a higher AD or metric is promoted only when all
+ * better paths become unreachable (floating static / backup route).
+ * Default: AD=1, metric=0.
+ *
+ * Tag: a 32-bit marker attached to a path and carried into the RIB.  Tag is
+ * shared by all nexthops in a path and is not part of the path identity.
+ * Nexthops at the same (distance, metric) always share one static_path
+ * regardless of their configured tag values; the last-configured tag applies
+ * to the whole group.  To assign independent tags, use different distances
+ * or metrics.
+ *
+ * ECMP: multiple static_nexthop entries under the same static_path are
+ * installed together as an equal-cost multipath group.  The weight field
+ * on each nexthop lets operators bias the traffic distribution within the
+ * group.
+ */
+
 /* Static route information */
 struct static_route_info {
 	struct static_vrf *svrf;
@@ -93,6 +135,8 @@ struct static_path {
 	struct static_path_list_item list;
 	/* Administrative distance. */
 	uint8_t distance;
+	/* Metric */
+	uint32_t metric;
 	/* Tag */
 	route_tag_t tag;
 	/* Table-id */
@@ -225,8 +269,8 @@ extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 					   struct static_vrf *svrf);
 extern void static_del_route(struct route_node *rn);
 
-extern struct static_path *static_add_path(struct route_node *rn,
-					   uint32_t table_id, uint8_t distance);
+extern struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
+					   uint8_t distance, uint32_t metric);
 extern void static_del_path(struct static_path *pn);
 
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -55,6 +55,7 @@ struct static_route_args {
 	const char *flag;
 	const char *tag;
 	const char *distance;
+	const char *metric;
 	const char *label;
 	const char *table;
 	const char *color;
@@ -115,6 +116,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	const char *buf_gate_str;
 	struct ipaddr gate_ip;
 	uint8_t distance = ZEBRA_STATIC_DISTANCE_DEFAULT;
+	uint32_t metric = 0;
 	route_tag_t tag = 0;
 	uint32_t table_id = 0;
 	const struct lyd_node *dnode;
@@ -216,6 +218,10 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	if (args->distance)
 		distance = strtol(args->distance, NULL, 10);
 
+	/* Metric */
+	if (args->metric)
+		metric = strtoul(args->metric, NULL, 10);
+
 	/* tag */
 	if (args->tag)
 		tag = strtoul(args->tag, NULL, 10);
@@ -233,7 +239,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 
 		/*
 		 * If there's already the same nexthop but with a different
-		 * distance, then remove it for the replacement.
+		 * distance or metric, then remove it for the replacement.
 		 */
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (dnode) {
@@ -248,7 +254,8 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		/* route + path processing */
 		snprintf(xpath_prefix, sizeof(xpath_prefix), FRR_STATIC_ROUTE_INFO_KEY_XPATH,
 			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
-			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance);
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id, distance,
+			 metric);
 
 		nb_cli_enqueue_change(vty, xpath_prefix, NB_OP_CREATE, NULL);
 
@@ -457,18 +464,10 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		if (orig_seg)
 			XFREE(MTYPE_TMP, orig_seg);
 	} else {
-		if (args->distance)
-			snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_XPATH,
-				 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix,
-				 buf_src_prefix, yang_afi_safi_value2identity(args->afi, args->safi),
-				 table_id, distance, buf_nh_type, args->nexthop_vrf, buf_gate_str,
-				 args->interface_name);
-		else
-			snprintf(ab_xpath, sizeof(ab_xpath),
-				 FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH, "frr-staticd:staticd",
-				 "staticd", args->vrf, buf_prefix, buf_src_prefix,
-				 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
-				 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
+		snprintf(ab_xpath, sizeof(ab_xpath), FRR_DEL_S_ROUTE_NH_KEY_NO_DISTANCE_XPATH,
+			 "frr-staticd:staticd", "staticd", args->vrf, buf_prefix, buf_src_prefix,
+			 yang_afi_safi_value2identity(args->afi, args->safi), table_id,
+			 buf_nh_type, args->nexthop_vrf, buf_gate_str, args->interface_name);
 
 		dnode = yang_dnode_get(vty->candidate_config->dnode, ab_xpath);
 		if (!dnode) {
@@ -519,6 +518,7 @@ DEFPY_YANG (ip_mroute_dist,
        ip_mroute_dist_cmd,
        "[no] ip mroute A.B.C.D/M$prefix <A.B.C.D$gate|INTERFACE$ifname> [{"
        "(1-255)$distance"
+       "|metric (0-4294967295)"
        "|bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}]"
        "}]",
        NO_STR
@@ -528,6 +528,8 @@ DEFPY_YANG (ip_mroute_dist,
        "Nexthop address\n"
        "Nexthop interface name\n"
        "Distance\n"
+       "Set metric for this route\n"
+       "Metric value\n"
        BFD_INTEGRATION_STR
        BFD_INTEGRATION_MULTI_HOP_STR
        BFD_INTEGRATION_SOURCE_STR
@@ -543,6 +545,7 @@ DEFPY_YANG (ip_mroute_dist,
 		.gateway = gate_str,
 		.interface_name = ifname,
 		.distance = distance_str,
+		.metric = metric_str,
 		.bfd = !!bfd,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
@@ -561,6 +564,7 @@ DEFPY_YANG(ip_route_blackhole,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+	  |metric (0-4294967295)                                              \
 	  |vrf NAME                                                           \
 	  |label WORD                                                         \
           |table (1-4294967295)                                               \
@@ -575,6 +579,8 @@ DEFPY_YANG(ip_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -589,6 +595,7 @@ DEFPY_YANG(ip_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -605,6 +612,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 	[{                                                                    \
 	  tag (1-4294967295)                                                  \
 	  |(1-255)$distance                                                   \
+	  |metric (0-4294967295)                                              \
 	  |label WORD                                                         \
 	  |table (1-4294967295)                                               \
           }]",
@@ -618,6 +626,8 @@ DEFPY_YANG(ip_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -631,6 +641,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -655,6 +666,7 @@ DEFPY_YANG(ip_route_address_interface,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |vrf NAME                                    \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
@@ -677,6 +689,8 @@ DEFPY_YANG(ip_route_address_interface,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -709,6 +723,7 @@ DEFPY_YANG(ip_route_address_interface,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -736,6 +751,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 	[{                                             \
 	  tag (1-4294967295)                           \
 	  |(1-255)$distance                            \
+	  |metric (0-4294967295)                       \
 	  |label WORD                                  \
 	  |table (1-4294967295)                        \
 	  |nexthop-vrf NAME                            \
@@ -757,6 +773,8 @@ DEFPY_YANG(ip_route_address_interface_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -788,6 +806,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -814,6 +833,7 @@ DEFPY_YANG(ip_route,
 	[{                                             	   \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |vrf NAME                                        \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
@@ -835,6 +855,8 @@ DEFPY_YANG(ip_route,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -866,6 +888,7 @@ DEFPY_YANG(ip_route,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -891,6 +914,7 @@ DEFPY_YANG(ip_route_vrf,
 	[{                                                 \
 	  tag (1-4294967295)                               \
 	  |(1-255)$distance                                \
+	  |metric (0-4294967295)                           \
 	  |label WORD                                      \
 	  |table (1-4294967295)                            \
 	  |nexthop-vrf NAME                                \
@@ -911,6 +935,8 @@ DEFPY_YANG(ip_route_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this route\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n"
@@ -941,6 +967,7 @@ DEFPY_YANG(ip_route_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -965,6 +992,7 @@ DEFPY_YANG(ipv6_route_blackhole,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
             |table (1-4294967295)                          \
@@ -980,6 +1008,8 @@ DEFPY_YANG(ipv6_route_blackhole,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
@@ -994,6 +1024,7 @@ DEFPY_YANG(ipv6_route_blackhole,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
@@ -1009,6 +1040,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
             |table (1-4294967295)                          \
           }]",
@@ -1023,6 +1055,8 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
       "Set tag for this route\n"
       "Tag value\n"
       "Distance value for this prefix\n"
+      "Set metric for this route\n"
+      "Metric value\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
       "The table number to configure\n")
@@ -1036,6 +1070,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
 		.flag = flag,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
@@ -1058,6 +1093,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1078,7 +1114,10 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1104,6 +1143,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1130,6 +1170,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1149,7 +1190,10 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1175,6 +1219,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1199,6 +1244,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |vrf NAME                                      \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
@@ -1218,7 +1264,10 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   VRF_CMD_HELP_STR MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1243,6 +1292,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1267,6 +1317,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
           [{                                               \
             tag (1-4294967295)                             \
             |(1-255)$distance                              \
+            |metric (0-4294967295)                         \
             |label WORD                                    \
 	    |table (1-4294967295)                          \
             |nexthop-vrf NAME                              \
@@ -1285,7 +1336,10 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	   "Null interface\n"
 	   "Set tag for this route\n"
 	   "Tag value\n"
-	   "Distance value for this prefix\n" MPLS_LABEL_HELPSTR
+	   "Distance value for this prefix\n"
+	   "Set metric for this route\n"
+	   "Metric value\n"
+	   MPLS_LABEL_HELPSTR
 	   "Table to configure\n"
 	   "The table number to configure\n" VRF_CMD_HELP_STR
 	   "Set weight of nexthop\n"
@@ -1310,6 +1364,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 		.interface_name = ifname,
 		.tag = tag_str,
 		.distance = distance_str,
+		.metric = metric_str,
 		.label = label,
 		.table = table_str,
 		.color = color_str,
@@ -1617,6 +1672,7 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	enum static_blackhole_type bh_type;
 	uint32_t tag;
 	uint8_t distance;
+	uint32_t metric;
 	struct mpls_label_iter iter;
 	struct srv6_seg_iter seg_iter;
 	enum srv6_headend_behavior srv6_encap_behavior = SRV6_HEADEND_BEHAVIOR_H_ENCAPS;
@@ -1692,6 +1748,10 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	distance = yang_dnode_get_uint8(path, "distance");
 	if (distance != ZEBRA_STATIC_DISTANCE_DEFAULT || show_defaults)
 		vty_out(vty, " %" PRIu8, distance);
+
+	metric = yang_dnode_get_uint32(path, "metric");
+	if (metric != 0 || show_defaults)
+		vty_out(vty, " metric %" PRIu32, metric);
 
 	iter.vty = vty;
 	iter.first = true;
@@ -1863,6 +1923,7 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 {
 	uint32_t table_id1, table_id2;
 	uint8_t distance1, distance2;
+	uint32_t metric1, metric2;
 
 	table_id1 = yang_dnode_get_uint32(dnode1, "table-id");
 	table_id2 = yang_dnode_get_uint32(dnode2, "table-id");
@@ -1873,7 +1934,13 @@ static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 	distance1 = yang_dnode_get_uint8(dnode1, "distance");
 	distance2 = yang_dnode_get_uint8(dnode2, "distance");
 
-	return (int)distance1 - (int)distance2;
+	if (distance1 != distance2)
+		return (int)distance1 - (int)distance2;
+
+	metric1 = yang_dnode_get_uint32(dnode1, "metric");
+	metric2 = yang_dnode_get_uint32(dnode2, "metric");
+
+	return numcmp(metric1, metric2);
 }
 
 static void static_segment_routing_cli_show(struct vty *vty, const struct lyd_node *dnode,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -441,6 +441,8 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);
 		api.distance = pn->distance;
 	}
+	SET_FLAG(api.message, ZAPI_MESSAGE_METRIC);
+	api.metric = pn->metric;
 	if (pn->tag) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_TAG);
 		api.tag = pn->tag;

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -444,7 +444,7 @@ void grpc_client_run_test(void)
 		snprintf(xpath_buf + slen, sizeof(xpath_buf) - slen,
 			 "[prefix='13.0.%d.0/24']"
 			 "[afi-safi='frr-routing:ipv4-unicast']/"
-			 "path-list[table-id='0'][distance='1']/"
+			 "path-list[table-id='0'][distance='1'][metric='0']/"
 			 "frr-nexthops/nexthop[nh-type='blackhole']"
 			 "[vrf='default'][gateway=''][interface='(null)']",
 			 i);
@@ -584,6 +584,7 @@ const char *json_expect1 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -638,6 +639,7 @@ const char *json_loadconf1 = R"NONCE(
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "frr-nexthops": {
                       "nexthop": [
                         {
@@ -683,6 +685,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -706,6 +709,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -729,6 +733,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -752,6 +757,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -775,6 +781,7 @@ const char *json_expect2 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -828,6 +835,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -851,6 +859,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -874,6 +883,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -897,6 +907,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -920,6 +931,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [
@@ -943,6 +955,7 @@ const char *json_expect3 = R"NONCE({
                   {
                     "table-id": 0,
                     "distance": 1,
+                    "metric": 0,
                     "tag": 0,
                     "frr-nexthops": {
                       "nexthop": [

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -180,7 +180,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -193,7 +193,7 @@ def test_mgmt_commit_check(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.2/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit check",
             ]
         }
@@ -250,7 +250,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -263,7 +263,7 @@ def test_mgmt_commit_apply(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.20/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/vrf default",
                 "mgmt commit apply",
             ]
         }
@@ -303,7 +303,7 @@ def test_mgmt_commit_abort(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit abort",
             ]
         }
@@ -355,7 +355,7 @@ def test_mgmt_delete_config(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.168.1.3/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -662,7 +662,7 @@ def test_mgmt_chaos_stop_start_frr(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }
@@ -738,7 +738,7 @@ def test_mgmt_chaos_kill_daemon(request):
     raw_config = {
         "r1": {
             "raw_config": [
-                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
+                "mgmt set-config /frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-staticd:staticd'][name='staticd'][vrf='default']/frr-staticd:staticd/route-list[prefix='192.1.11.200/32'][src-prefix='::/0'][afi-safi='frr-routing:ipv4-unicast']/path-list[table-id='0'][distance='1'][metric='0']/frr-nexthops/nexthop[nh-type='blackhole'][vrf='default'][gateway=''][interface='(null)']/bh-type unspec",
                 "mgmt commit apply",
             ]
         }

--- a/tests/topotests/static_route_distance/r1/frr.conf
+++ b/tests/topotests/static_route_distance/r1/frr.conf
@@ -1,0 +1,11 @@
+interface r1-eth0
+  ip address 192.0.2.1/24
+  ipv6 address 2001:db8:0:1::1/64
+
+interface r1-eth1
+  ip address 198.51.100.1/24
+  ipv6 address 2001:db8:0:2::1/64
+
+interface r1-eth2
+  ip address 203.0.113.1/24
+  ipv6 address 2001:db8:0:3::1/64

--- a/tests/topotests/static_route_distance/test_static_route_distance.py
+++ b/tests/topotests/static_route_distance/test_static_route_distance.py
@@ -1,0 +1,757 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path administrative distance for static routes.
+
+Design: administrative distance, metric, and tag live in static_path, which
+is keyed by (table-id, distance, metric).  Tag is a modifiable leaf shared by
+all nexthops in a path.  Different distances or metrics produce separate path
+objects, enabling floating static routes (primary/backup) under a single
+prefix.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. AD replacement: reconfiguring the same nexthop with a new AD must
+     update the existing RIB entry in place (NB_OP_MODIFY) and remove the
+     stale old-distance zebra entry — not create a duplicate.
+
+  2. Floating static route: two nexthops at different ADs under the same
+     prefix; the lower-AD nexthop is active in the FIB and the higher-AD
+     standby is promoted when the primary is removed.
+
+  3. ECMP: two nexthops at the same AD are both active in the FIB.
+     Removing one ECMP member leaves the other active at the same AD.
+
+  4. ECMP with floating standby: primary ECMP group (NH1+NH2, AD 10) plus
+     a standby (NH3, AD 20).  Removing primaries one by one shrinks the
+     active group; the standby is promoted only when the last primary is
+     removed.
+
+  5. ECMP AD change (promote/demote): a nexthop moves in and out of the
+     ECMP group by having its AD changed — covering both promotion
+     (standby joins the ECMP group) and demotion (ECMP member becomes
+     standby), and re-promotion back into the group.
+
+  6. Delete standby only: deleting the standby nexthop must leave the
+     primary completely unaffected; the standby RIB entry is fully
+     withdrawn from zebra.
+
+  7. Delete primary then standby: deleting the primary promotes the
+     standby; deleting the standby fully withdraws the route from both
+     RIB and FIB.
+
+  8. Delete without distance and metric: deletion always uses a lazy search
+     keyed on nexthop identity; distance and metric arguments are ignored.
+     'no ip route X/M via Y' removes the route regardless of the configured
+     AD or metric.
+"""
+#
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+# Three nexthop addresses reachable via r1-eth0, eth1, eth2 respectively.
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _route_distances(router, prefix, ipv6=False):
+    """Return the set of administrative distances present in the RIB for prefix."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    if prefix not in json_data:
+        return set()
+    return {entry["distance"] for entry in json_data[prefix]}
+
+
+def _route_nexthops(router, prefix, ipv6=False):
+    """Return the set of nexthop IPs from the selected (best-path) route entry.
+
+    The nexthop-level 'fib' flag in the JSON output indicates whether the nexthop group is installed
+    in the kernel nexhop table — it can be true even for non-selected routes that
+    share a nexhop group.  The route-level 'selected' flag is the correct
+    indicator of which entry is the active best path.
+    """
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    if prefix not in json_data:
+        return set()
+    active = set()
+    for entry in json_data[prefix]:
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("active"):
+                active.add(nh.get("ip", nh.get("interfaceName", "")))
+    return active
+
+
+def _check_distances(router, prefix, expected, ipv6=False):
+    """Return None when RIB distances equal expected, else return the actual set."""
+    actual = _route_distances(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_route(router, prefix, expected, ipv6=False):
+    """Return None when active route nexthops equal expected, else return the actual set."""
+    actual = _route_nexthops(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_distances(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_distances, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_route(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_route, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return the list of static-route lines for prefix in 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    """Return None when running-config lines match expected_lines (as a set), else actual."""
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    expected = set(expected_lines)
+    return None if actual == expected else actual
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(
+        _check_running, router, prefix, expected_lines, ipv6
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test: AD replacement
+# ---------------------------------------------------------------------------
+
+def run_ad_replacement(ipv6=False):
+    """
+    Same nexthop reconfigured with a new AD must replace the old RIB entry
+    and leave running-config with exactly one entry at the new AD.
+
+    Steps:
+      1. Install route via NH1 at AD 10.
+      2. Reconfigure the same route via NH1 at AD 20.
+      3. Verify only AD 20 is present in RIB; AD 10 entry is gone.
+      4. Verify running-config shows exactly 'ip route ... NH1 20', not the old '... 10'.
+      5. Clean up; verify running-config is empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"AD replacement [1]: expected {{10}}, got {result}"
+
+    # Step 2: same nexthop, new AD — must replace, not duplicate
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_distances(r1, prefix, {20}, ipv6)
+    assert result is None, (
+        f"AD replacement [2]: stale AD 10 present or AD 20 missing; got {result}"
+    )
+
+    # Step 3: running-config must show exactly one entry at AD 20, not AD 10
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"AD replacement [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"AD replacement [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"AD replacement [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ad_replacement_ipv4():
+    "Same IPv4 nexthop reconfigured with new AD replaces old RIB entry."
+    run_ad_replacement(ipv6=False)
+
+
+def test_ad_replacement_ipv6():
+    "Same IPv6 nexthop reconfigured with new AD replaces old RIB entry."
+    run_ad_replacement(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: floating static route (two different nexthops, different ADs)
+# ---------------------------------------------------------------------------
+
+def run_floating_static(ipv6=False):
+    """
+    Two nexthops under the same prefix with independent ADs.
+
+    Steps:
+      1. Install primary NH1 at AD 10 and standby NH2 at AD 20.
+      2. Verify NH1 is active in FIB (lower AD wins).
+      3. Remove NH1; verify NH2 is promoted to active.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Floating static [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: lower-AD nexthop active
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, f"Floating static [2]: expected {nh1} active, got {result}"
+
+    # Step 3: remove primary → standby promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Floating static [3]: expected {nh2} active after primary removed, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"Floating static [cleanup]: route not removed; got {result}"
+
+
+def test_floating_static_ipv4():
+    "IPv4 floating static: lower-AD nexthop active, standby promoted on primary removal."
+    run_floating_static(ipv6=False)
+
+
+def test_floating_static_ipv6():
+    "IPv6 floating static: lower-AD nexthop active, standby promoted on primary removal."
+    run_floating_static(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP (multiple nexthops at the same AD)
+# ---------------------------------------------------------------------------
+
+def run_ecmp(ipv6=False):
+    """
+    Two nexthops at the same AD are both active in the FIB (ECMP).
+    Removing one ECMP member leaves the remaining one active.
+
+    Steps:
+      1. Install NH1 and NH2 both at AD 10.
+      2. Verify both are active in FIB.
+      3. Remove NH1; verify NH2 remains active at AD 10.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"ECMP [1]: expected single AD {{10}}, got {result}"
+
+    # Step 2: both nexthops active (ECMP)
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, f"ECMP [2]: expected both {nh1},{nh2} active, got {result}"
+
+    # Step 3: remove one ECMP member
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP [3]: expected only {nh2} active after {nh1} removed, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, f"ECMP [3]: AD should still be {{10}}, got {result}"
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_ipv4():
+    "IPv4 ECMP: two nexthops at same AD both active; removing one leaves the other."
+    run_ecmp(ipv6=False)
+
+
+def test_ecmp_ipv6():
+    "IPv6 ECMP: two nexthops at same AD both active; removing one leaves the other."
+    run_ecmp(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: ECMP with floating standby
+# ---------------------------------------------------------------------------
+
+def run_ecmp_with_standby(ipv6=False):
+    """
+    ECMP primary group (NH1+NH2 at AD 10) plus a floating standby (NH3 at AD 20).
+
+    Steps:
+      1. Install NH1, NH2 at AD 10 and NH3 at AD 20.
+      2. Verify NH1 and NH2 are active (ECMP); NH3 is in RIB but not FIB.
+      3. Remove NH1; verify NH2 is the sole active nexhop at AD 10.
+         NH3 remains standby (still not in FIB).
+      4. Remove NH2 (last primary); verify NH3 is promoted to active.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: ECMP primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10\n"
+        f"ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"ECMP+standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: NH1+NH2 active (ECMP), NH3 standby (not in FIB)
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [2]: expected {nh1},{nh2} active (ECMP), got {result}"
+    )
+
+    # Step 3: remove NH1 — NH2 sole primary, NH3 still standby
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected only {nh2} active, NH3 still standby, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [3]: expected {{10,20}} in RIB, got {result}"
+    )
+
+    # Step 4: remove last primary NH2 — standby NH3 promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_route(r1, prefix, {nh3}, ipv6)
+    assert result is None, (
+        f"ECMP+standby [4]: expected {nh3} promoted after all primaries removed, got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh3} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP+standby [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_with_standby_ipv4():
+    "IPv4 ECMP primary group with floating standby; standby promoted when all primaries removed."
+    run_ecmp_with_standby(ipv6=False)
+
+
+def test_ecmp_with_standby_ipv6():
+    "IPv6 ECMP primary group with floating standby; standby promoted when all primaries removed."
+    run_ecmp_with_standby(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: promote/demote nexthops by changing AD
+# ---------------------------------------------------------------------------
+
+def run_ecmp_ad_change(ipv6=False):
+    """
+    A nexthop moves in and out of the ECMP group by having its AD changed.
+
+    Steps:
+      1. NH1 at AD 10 (sole primary), NH2 at AD 20 (standby).
+         Verify NH1 active, NH2 not in FIB.
+      2. Change NH2 AD 20 → 10: NH2 joins the ECMP group.
+         Verify both NH1 and NH2 active; only AD 10 in RIB (AD 20 gone).
+      3. Change NH1 AD 10 → 20: NH1 leaves the ECMP group and becomes standby.
+         Verify NH2 sole primary at AD 10; NH1 standby at AD 20.
+      4. Change NH1 AD 20 → 10: NH1 rejoins the ECMP group.
+         Verify both NH1 and NH2 active again at AD 10.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 primary at AD 10, NH2 standby at AD 20
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, f"ECMP AD change [1]: expected only {nh1} active, got {result}"
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"ECMP AD change [1]: expected {{10,20}} in RIB, got {result}"
+
+    # Step 2: promote NH2 into ECMP group (AD 20 → 10)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10\n")
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [2]: expected both {nh1},{nh2} active after NH2 promoted, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [2]: stale AD 20 still present after NH2 promoted, got {result}"
+    )
+    # running-config: both nexthops at AD 10, no stale AD 20 entry
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} 10",
+         f"ip{ip_ver} route {prefix} {nh2} 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [2]: running-config mismatch after NH2 promoted; got {result}"
+    )
+
+    # Step 3: demote NH1 to standby (AD 10 → 20)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 20\n")
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [3]: expected only {nh2} active after NH1 demoted, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [3]: expected {{10,20}} in RIB after NH1 demoted, got {result}"
+    )
+    # running-config: NH2 at AD 10 (primary), NH1 at AD 20 (standby), no duplicate
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh2} 10",
+         f"ip{ip_ver} route {prefix} {nh1} 20"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [3]: running-config mismatch after NH1 demoted; got {result}"
+    )
+
+    # Step 4: NH1 rejoins ECMP group (AD 20 → 10)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_route(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [4]: expected both {nh1},{nh2} active after NH1 rejoined, got {result}"
+    )
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"ECMP AD change [4]: stale AD 20 still present after NH1 rejoined, got {result}"
+    )
+    # running-config: both nexthops at AD 10, no stale AD 20 entry
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh1} 10",
+         f"ip{ip_ver} route {prefix} {nh2} 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"ECMP AD change [4]: running-config mismatch after NH1 rejoined; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP AD change [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"ECMP AD change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_ecmp_ad_change_ipv4():
+    "IPv4: nexthop moves in and out of ECMP group by changing its AD."
+    run_ecmp_ad_change(ipv6=False)
+
+
+def test_ecmp_ad_change_ipv6():
+    "IPv6: nexthop moves in and out of ECMP group by changing its AD."
+    run_ecmp_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: targeted deletion scenarios
+# ---------------------------------------------------------------------------
+
+def run_delete_standby(ipv6=False):
+    """
+    Deleting the standby nexhop must not affect the active primary.
+
+    Steps:
+      1. NH1 at AD 10 (primary), NH2 at AD 20 (standby).
+      2. Delete NH2 (standby only).
+      3. Verify NH1 still active; AD 20 entry completely gone from RIB.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Delete standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: delete standby only
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+
+    # Step 3: primary unaffected; standby RIB entry completely withdrawn
+    result = _expect_distances(r1, prefix, {10}, ipv6)
+    assert result is None, (
+        f"Delete standby [3]: expected only {{10}} in RIB after standby deleted, got {result}"
+    )
+    result = _expect_route(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Delete standby [3]: primary {nh1} should still be active, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, f"Delete standby [cleanup]: route not fully removed, got {result}"
+
+
+def run_delete_primary_then_standby(ipv6=False):
+    """
+    Delete primary first (standby takes over), then delete standby; route must
+    be completely withdrawn from RIB and FIB after the last nexhop is removed.
+
+    Steps:
+      1. NH1 at AD 10 (primary), NH2 at AD 20 (standby).
+      2. Delete NH1; verify NH2 promoted and AD 10 entry gone.
+      3. Delete NH2; verify route is completely gone from RIB and FIB.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary + standby
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20\n"
+    )
+    result = _expect_distances(r1, prefix, {10, 20}, ipv6)
+    assert result is None, f"Delete primary+standby [1]: expected {{10,20}}, got {result}"
+
+    # Step 2: delete primary — standby promoted, AD 10 entry gone
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_distances(r1, prefix, {20}, ipv6)
+    assert result is None, (
+        f"Delete primary+standby [2]: expected only {{20}} after primary deleted, got {result}"
+    )
+    result = _expect_route(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Delete primary+standby [2]: expected {nh2} promoted to active, got {result}"
+    )
+
+    # Step 3: delete standby — route fully withdrawn
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 20\n")
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete primary+standby [3]: route should be fully gone, got {result}"
+    )
+    result = _expect_route(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete primary+standby [3]: FIB entry should be gone, got {result}"
+    )
+
+
+def test_delete_standby_ipv4():
+    "IPv4: deleting the standby nexhop leaves the primary completely unaffected."
+    run_delete_standby(ipv6=False)
+
+
+def test_delete_standby_ipv6():
+    "IPv6: deleting the standby nexhop leaves the primary completely unaffected."
+    run_delete_standby(ipv6=True)
+
+
+def test_delete_primary_then_standby_ipv4():
+    "IPv4: delete primary (standby promoted), then delete standby (route fully withdrawn)."
+    run_delete_primary_then_standby(ipv6=False)
+
+
+def test_delete_primary_then_standby_ipv6():
+    "IPv6: delete primary (standby promoted), then delete standby (route fully withdrawn)."
+    run_delete_primary_then_standby(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test: deletion without specifying distance
+# ---------------------------------------------------------------------------
+
+def run_delete_without_distance(ipv6=False):
+    """
+    Deletion always uses a lazy search keyed on nexthop identity; distance and
+    metric arguments are ignored.  'no ip route X/M via Y' finds and removes
+    the nexthop regardless of what AD or metric was configured.
+
+    Steps:
+      1. Install route via NH1 at non-default AD 50.
+      2. Delete using 'no ip route X/M via NH1' with no distance specified.
+      3. Verify route is completely gone.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at non-default AD 50
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 50\n")
+    result = _expect_distances(r1, prefix, {50}, ipv6)
+    assert result is None, f"Delete without distance [1]: expected {{50}}, got {result}"
+
+    # Step 2: delete without specifying distance
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+
+    # Step 3: route must be gone from RIB and running-config
+    result = _expect_distances(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Delete without distance [3]: route at AD 50 not removed by 'no' without distance; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Delete without distance [3]: stale running-config entry after delete; got {result}"
+    )
+
+
+def test_delete_without_distance_ipv4():
+    "IPv4: 'no ip route X/M via Y' without distance and metric removes the route regardless of the configured AD or metric."
+    run_delete_without_distance(ipv6=False)
+
+
+def test_delete_without_distance_ipv6():
+    "IPv6: 'no ip route X/M via Y' without distance and metric removes the route regardless of the configured AD or metric."
+    run_delete_without_distance(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/static_route_distance/test_static_route_metric.py
+++ b/tests/topotests/static_route_distance/test_static_route_metric.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path metric for static routes.
+
+Design: metric is a YANG path-list key alongside table-id and distance.
+Nexthops sharing the same (table-id, distance, metric) tuple form one ECMP
+group.  Zebra keeps separate route_entry objects for routes with the same
+(type, instance, distance) but different metrics because rib_compare_routes()
+treats static routes with different metrics as non-equal, and the
+process_subq_early_route_delete() loop skips entries whose metric does not
+match the delete request.  Zebra selects the lower-metric entry as best —
+enabling metric-based floating routes within the same administrative distance.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. Metric replacement: reconfiguring the same nexthop with a new metric
+     must update the existing RIB entry (including the active metric value
+     reported by zebra) and remove the stale old-metric entry — not
+     duplicate it.
+
+  2. ECMP at same (distance, metric): two nexthops with matching distance
+     and metric are both active in the FIB.  Removing one leaves the other
+     active at the same (distance, metric).
+
+  3. Metric-based floating within same distance: NH1@(AD=10, metric=100)
+     and NH2@(AD=10, metric=200) are kept as separate RIB entries; the lower
+     metric wins in zebra.  Removing NH1 promotes NH2.
+
+  4. Metric change (promote/demote): a nexthop moves in and out of the
+     ECMP group by having its metric changed — covering both promotion
+     (standby joins ECMP group) and demotion (ECMP member becomes standby),
+     and re-promotion back into the group.
+
+  5. Nexthop-identity deletion: deletion always uses a lazy search keyed on
+     nexthop identity (gateway address, interface, or blackhole type);
+     distance and metric arguments are ignored.  Any form of 'no ip route
+     X/M via Y' removes the route regardless of which distance or metric it
+     was installed with.  A two-nexthop scenario verifies that deleting one
+     nexthop leaves the other intact — exercising zebra's delete-lookup loop
+     metric check (rib_compare_routes / process_subq_early_route_delete).
+
+  6. Running-config format: metric appears after distance in the
+     'show running-config' output; distance=default is omitted; metric=0
+     is omitted.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_keys(router, prefix, ipv6=False):
+    """Return set of (distance, metric) tuples present in the RIB for prefix."""
+    return {
+        (e.get("distance", 0), e.get("metric", 0))
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _active_nexthops(router, prefix, ipv6=False):
+    """Return set of nexthop IPs from the selected (best-path) route entry."""
+    active = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        if not entry.get("selected"):
+            continue
+        for nh in entry.get("nexthops", []):
+            if nh.get("active"):
+                active.add(nh.get("ip", nh.get("interfaceName", "")))
+    return active
+
+
+def _active_metric(router, prefix, ipv6=False):
+    """Return the metric of the selected (best-path) RIB entry, or None if absent."""
+    for entry in _route_entries(router, prefix, ipv6):
+        if entry.get("selected"):
+            return entry.get("metric", 0)
+    return None
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_keys(router, prefix, expected, ipv6=False):
+    actual = _route_keys(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_nexthops(router, prefix, expected, ipv6=False):
+    actual = _active_nexthops(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_metric(router, prefix, expected, ipv6=False):
+    actual = _active_metric(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_keys(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_keys, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_nexthops(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_nexthops, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_metric(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_metric, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(_check_running, router, prefix, expected_lines, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Metric replacement
+# ---------------------------------------------------------------------------
+
+
+def run_metric_replacement(ipv6=False):
+    """
+    Same nexthop reconfigured with a new metric must replace the old RIB
+    entry and leave running-config with exactly one entry at the new metric.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100).
+      2. Reconfigure NH1 at (AD=10, metric=200) — must replace, not duplicate.
+      3. Verify only (10, 200) is in RIB; (10, 100) entry is gone.
+      4. Verify running-config shows '... NH1 10 metric 200', not 'metric 100'.
+      5. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at (AD=10, metric=100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric replacement [1]: expected {{(10,100)}}, got {result}"
+
+    # Step 2: same nexthop, new metric — must replace, not duplicate
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, {(10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric replacement [2]: stale metric 100 present or metric 200 missing; got {result}"
+    )
+
+    # Verify zebra reports the updated metric value
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"Metric replacement [2]: active metric should be 200 in RIB; got {result}"
+    )
+
+    # Step 3: running-config shows exactly one entry at metric 200
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} 10 metric 200"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Metric replacement [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric replacement [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric replacement [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_metric_replacement_ipv4():
+    "IPv4: same nexthop reconfigured with new metric replaces old RIB entry."
+    run_metric_replacement(ipv6=False)
+
+
+def test_metric_replacement_ipv6():
+    "IPv6: same nexthop reconfigured with new metric replaces old RIB entry."
+    run_metric_replacement(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: ECMP at same (distance, metric)
+# ---------------------------------------------------------------------------
+
+
+def run_ecmp_same_metric(ipv6=False):
+    """
+    Two nexthops at the same (distance, metric) are both active in the FIB.
+    Removing one ECMP member leaves the other active at the same key.
+
+    Steps:
+      1. Install NH1 and NH2 both at (AD=10, metric=100).
+      2. Verify both are active (ECMP); only one (10, 100) entry in RIB.
+      3. Remove NH1; verify NH2 remains active at (10, 100).
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same (AD, metric)
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 100\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"ECMP same metric [1]: expected {{(10,100)}}, got {result}"
+
+    # Step 2: both nexthops active (ECMP)
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [2]: expected both {nh1},{nh2} active, got {result}"
+    )
+
+    # Step 3: remove one ECMP member
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [3]: expected only {nh2} active after {nh1} removed, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"ECMP same metric [3]: RIB key should still be {{(10,100)}}, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"ECMP same metric [cleanup]: route not removed; got {result}"
+
+
+def test_ecmp_same_metric_ipv4():
+    "IPv4 ECMP: two nexthops at same (distance, metric) both active; removing one leaves the other."
+    run_ecmp_same_metric(ipv6=False)
+
+
+def test_ecmp_same_metric_ipv6():
+    "IPv6 ECMP: two nexthops at same (distance, metric) both active; removing one leaves the other."
+    run_ecmp_same_metric(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Metric-based floating within same distance
+# ---------------------------------------------------------------------------
+
+
+def run_metric_floating(ipv6=False):
+    """
+    Two nexthops at the same distance but different metrics are kept as
+    separate RIB entries (ZEBRA_FLAG_RR_USE_METRIC).  Zebra selects the
+    lower-metric path as best; the higher-metric path is standby.
+    Removing the primary promotes the standby.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100) and NH2 at (AD=10, metric=200).
+      2. Verify RIB has both keys; NH1 is active (lower metric wins).
+      3. Remove NH1; verify NH2 is promoted to active.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: primary (lower metric) + standby (higher metric), same distance
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric floating [1]: expected {{(10,100),(10,200)}}, got {result}"
+    )
+
+    # Step 2: lower-metric nexthop is active
+    result = _expect_nexthops(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Metric floating [2]: expected {nh1} active (lower metric), got {result}"
+    )
+    result = _expect_metric(r1, prefix, 100, ipv6)
+    assert result is None, (
+        f"Metric floating [2]: expected active metric=100, got {result}"
+    )
+
+    # Step 3: remove primary → standby promoted
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Metric floating [3]: expected {nh2} promoted after {nh1} removed, got {result}"
+    )
+    result = _expect_metric(r1, prefix, 200, ipv6)
+    assert result is None, (
+        f"Metric floating [3]: expected active metric=200 after promotion, got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric floating [cleanup]: route not removed; got {result}"
+
+
+def test_metric_floating_ipv4():
+    "IPv4: NH at lower metric active; higher-metric NH is standby and promoted on primary removal."
+    run_metric_floating(ipv6=False)
+
+
+def test_metric_floating_ipv6():
+    "IPv6: NH at lower metric active; higher-metric NH is standby and promoted on primary removal."
+    run_metric_floating(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Metric change (promote/demote)
+# ---------------------------------------------------------------------------
+
+
+def run_metric_change(ipv6=False):
+    """
+    A nexthop moves in and out of the ECMP group by having its metric changed.
+
+    Steps:
+      1. NH1 at (AD=10, metric=100) sole primary; NH2 at (AD=10, metric=200) standby.
+         Verify NH1 active, NH2 not.
+      2. Change NH2 metric=200 → 100: NH2 joins the ECMP group.
+         Verify both NH1 and NH2 active; only (10,100) in RIB (old (10,200) gone).
+      3. Change NH1 metric=100 → 200: NH1 demoted to standby.
+         Verify NH2 sole primary at (10,100); NH1 standby at (10,200).
+      4. Change NH1 metric=200 → 100: NH1 rejoins ECMP group.
+         Verify both NH1 and NH2 active at (10,100).
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: NH1 primary at metric=100, NH2 standby at metric=200
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_nexthops(r1, prefix, {nh1}, ipv6)
+    assert result is None, (
+        f"Metric change [1]: expected only {nh1} active, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric change [1]: expected {{(10,100),(10,200)}} in RIB, got {result}"
+    )
+
+    # Step 2: promote NH2 into ECMP group (metric=200 → 100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [2]: expected both {nh1},{nh2} active after NH2 promoted, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric change [2]: stale (10,200) still present after NH2 promoted, got {result}"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} 10 metric 100",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Metric change [2]: running-config mismatch after NH2 promoted; got {result}"
+    )
+
+    # Step 3: demote NH1 to standby (metric=100 → 200)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 200\n")
+    result = _expect_nexthops(r1, prefix, {nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [3]: expected only {nh2} active after NH1 demoted, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric change [3]: expected {{(10,100),(10,200)}} in RIB after NH1 demoted, got {result}"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh2} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 200",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Metric change [3]: running-config mismatch after NH1 demoted; got {result}"
+    )
+
+    # Step 4: NH1 rejoins ECMP group (metric=200 → 100)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_nexthops(r1, prefix, {nh1, nh2}, ipv6)
+    assert result is None, (
+        f"Metric change [4]: expected both {nh1},{nh2} active after NH1 rejoined, got {result}"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, (
+        f"Metric change [4]: stale (10,200) still present after NH1 rejoined, got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 10 metric 100\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric change [cleanup]: route not removed; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_metric_change_ipv4():
+    "IPv4: nexthop moves in and out of ECMP group by changing its metric."
+    run_metric_change(ipv6=False)
+
+
+def test_metric_change_ipv6():
+    "IPv6: nexthop moves in and out of ECMP group by changing its metric."
+    run_metric_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Metric-aware deletion
+# ---------------------------------------------------------------------------
+
+
+def run_nexthop_identity_deletion(ipv6=False):
+    """
+    Verify deletion always uses nexthop identity (lazy search); distance and
+    metric arguments are ignored:
+
+      a. Both distance and metric specified — removes the route.
+      b. Distance only (no metric) — still removes the route; metric is ignored.
+      c. Neither distance nor metric — removes the route.
+      d. Two nexthops at different metrics; deleting one by nexthop identity
+         leaves the other intact — directly exercises zebra's delete-lookup
+         loop metric check (rib_compare_routes /
+         process_subq_early_route_delete).
+      e. Metric only (no distance) — removes the route regardless of the
+         metric value supplied.
+
+    Steps (case a):
+      1. Install NH1 at (AD=10, metric=100).
+      2. Delete: 'no ip route ... NH1 10 metric 100'.
+      3. Verify route is gone.
+
+    Steps (case b):
+      4. Install NH1 at (AD=10, metric=100).
+      5. Delete without metric: 'no ip route ... NH1 10'.
+         Lazy search finds NH1 regardless of metric.
+      6. Verify route is gone.
+
+    Steps (case c):
+      7. Install NH1 at (AD=10, metric=100).
+      8. Delete without distance or metric: 'no ip route ... NH1'.
+      9. Verify route is gone.
+
+    Steps (case d):
+      10. Install NH1 at (AD=10, metric=100) and NH2 at (AD=10, metric=200).
+      11. Verify both {(10,100),(10,200)} are in the RIB.
+      12. Delete NH1 by nexthop identity: 'no ip route ... NH1 10 metric 100'.
+      13. Verify only {(10,200)} remains.
+      14. Cleanup: delete NH2.
+
+    Steps (case e):
+      15. Install NH1 at (AD=1 default, metric=100).
+      16. Delete with a different metric value: 'no ip route ... NH1 metric 200'.
+          Lazy search finds NH1 regardless of the metric argument.
+      17. Verify route is gone.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Case (a): exact-key delete removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (a) [1]: expected {{(10,100)}}, got {result}"
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (a) [2]: exact-key delete failed; got {result}"
+    )
+
+    # Case (b): delete with distance but no metric — lazy search removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (b) [4]: expected {{(10,100)}}, got {result}"
+
+    # Delete without metric — lazy search finds NH1 regardless of metric
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (b) [5]: lazy delete (distance only) should remove route; got {result}"
+    )
+
+    # Case (c): lazy delete (no distance, no metric) finds and removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 100)}, ipv6)
+    assert result is None, f"Metric deletion (c) [7]: expected {{(10,100)}}, got {result}"
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1}\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (c) [8]: lazy delete should remove route at any metric; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Metric deletion (c) [9]: stale running-config after lazy delete; got {result}"
+    )
+
+    # Case (d): two routes at different metrics; delete one; the other must survive.
+    # NH1 and NH2 are used so both path-lists co-exist (nexthop uniqueness only
+    # enforces one path-list per nexthop address, not per prefix).
+    # This directly exercises zebra's delete-lookup loop: the loop must skip the
+    # metric=200 entry and remove only metric=100.
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 metric 200\n"
+    )
+    result = _expect_keys(r1, prefix, {(10, 100), (10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (d) [11]: expected {{(10,100),(10,200)}}; got {result}"
+    )
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_keys(r1, prefix, {(10, 200)}, ipv6)
+    assert result is None, (
+        f"Metric deletion (d) [13]: metric=200 entry should survive deletion of "
+        f"metric=100; got {result}"
+    )
+
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh2} 10 metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, f"Metric deletion (d) [cleanup]: got {result}"
+
+    # Case (e): metric-only delete (no distance) — lazy search removes the route
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} metric 100\n")
+    result = _expect_keys(r1, prefix, {(1, 100)}, ipv6)
+    assert result is None, f"Metric deletion (e) [15]: expected {{(1,100)}}; got {result}"
+
+    # Metric value in 'no' command is ignored — lazy search finds NH1 and removes it
+    r1.vtysh_multicmd(f"configure\nno ip{ip_ver} route {prefix} {nh1} metric 200\n")
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Metric deletion (e) [16]: lazy delete (metric-only) should remove route; got {result}"
+    )
+
+
+def test_nexthop_identity_deletion_ipv4():
+    "IPv4: deletion always uses nexthop identity; distance and metric arguments are ignored."
+    run_nexthop_identity_deletion(ipv6=False)
+
+
+def test_nexthop_identity_deletion_ipv6():
+    "IPv6: deletion always uses nexthop identity; distance and metric arguments are ignored."
+    run_nexthop_identity_deletion(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Running-config format
+# ---------------------------------------------------------------------------
+
+
+def run_running_config_format(ipv6=False):
+    """
+    Verify that metric appears after distance in 'show running-config' output,
+    that a zero metric is omitted, and that the default distance (1) is omitted.
+
+    Steps:
+      1. Install NH1 at (AD=10, metric=100): expect '... NH1 10 metric 100'.
+      2. Install NH2 at (AD=1 default, metric=50): expect '... NH2 metric 50'
+         (distance 1 is default → omitted).
+      3. Install NH3 at (AD=20, metric=0 default): expect '... NH3 20'
+         (metric 0 is default → omitted).
+      4. Clean up all three.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    nh3 = NH3_V6 if ipv6 else NH3_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: non-default AD, non-zero metric
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh1} 10 metric 100\n")
+    result = _expect_running(
+        r1, prefix, [f"ip{ip_ver} route {prefix} {nh1} 10 metric 100"], ipv6
+    )
+    assert result is None, (
+        f"Running-config format [1]: expected '... NH1 10 metric 100'; got {result}"
+    )
+
+    # Step 2: default AD (omitted), non-zero metric
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh2} metric 50\n")
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} metric 50",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Running-config format [2]: expected '... NH2 metric 50' (no distance); got {result}"
+    )
+
+    # Step 3: non-default AD, zero metric (omitted)
+    r1.vtysh_multicmd(f"configure\nip{ip_ver} route {prefix} {nh3} 20\n")
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} 10 metric 100",
+            f"ip{ip_ver} route {prefix} {nh2} metric 50",
+            f"ip{ip_ver} route {prefix} {nh3} 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Running-config format [3]: expected '... NH3 20' (no metric); got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 metric 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2}\n"
+        f"no ip{ip_ver} route {prefix} {nh3} 20\n"
+    )
+    result = _expect_keys(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Running-config format [cleanup]: route not fully removed; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Running-config format [cleanup]: stale running-config; got {result}"
+    )
+
+
+def test_running_config_format_ipv4():
+    "IPv4: metric appears after distance in running-config; defaults (dist=1, metric=0) omitted."
+    run_running_config_format(ipv6=False)
+
+
+def test_running_config_format_ipv6():
+    "IPv6: metric appears after distance in running-config; defaults (dist=1, metric=0) omitted."
+    run_running_config_format(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/static_route_distance/test_static_route_tag.py
+++ b/tests/topotests/static_route_distance/test_static_route_tag.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2026, Palo Alto Networks, Inc.
+# Enke Chen <enchen@paloaltonetworks.com>
+#
+
+"""
+Test per-path tag for static routes.
+
+Design: tag lives in static_path alongside distance and metric.  The
+path-list key is (table-id, distance, metric); tag is a modifiable leaf.
+Each path groups ECMP nexthops that share the same table, distance, and
+metric; the tag is shared by all nexthops in a path.
+
+Note: zebra keys routes by (prefix, protocol, table, distance) and ignores
+tag, so tag is advisory metadata only.  Nexthops at the same AD always share
+one zebra slot regardless of tag.
+
+Topology: r1 with three Ethernet interfaces, each connected to a switch
+(s1/s2/s3), providing three independent nexthop addresses (NH1, NH2, NH3).
+All tests run for both IPv4 and IPv6.
+
+Test cases:
+
+  1. Basic tag: install a route with a tag; verify the tag appears in
+     the RIB (show ip route json) and in running-config.
+
+  2. Tag per path: NH1@AD10+tag=100 and NH2@AD20+tag=200.  Each path
+     carries an independent tag.  Verify both paths have the correct
+     tags in the RIB and running-config.
+
+  3. Tag change: change the tag on an existing path; verify the new tag
+     is reflected in the RIB and running-config, and the old tag is gone.
+
+  4. Tag with AD change: NH1@AD10+tag=100 reconfigured to AD20+tag=200.
+     Verify running-config shows exactly one entry at the new (AD, tag)
+     with no stale entry at the old (AD, tag).
+
+  5. Same AD, different tag: NH1@AD10+tag=100 and NH2@AD10+tag=200.  Since
+     both nexthops share the same path-list (keyed by (distance, metric)),
+     the path tag is the last-configured value (200).  Both nexthops form
+     ECMP under one path.  Removing NH1 leaves NH2 in the RIB intact.
+"""
+
+import functools
+import json
+import os
+import sys
+
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+NH1_V4 = "192.0.2.2"
+NH2_V4 = "198.51.100.2"
+NH3_V4 = "203.0.113.2"
+NH1_V6 = "2001:db8:0:1::2"
+NH2_V6 = "2001:db8:0:2::2"
+NH3_V6 = "2001:db8:0:3::2"
+
+PREFIX_V4 = "10.0.0.0/24"
+PREFIX_V6 = "2001:db8:f::/48"
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",), "s2": ("r1",), "s3": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    for _, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _route_entries(router, prefix, ipv6=False):
+    """Return the list of route-entry dicts from 'show ip route json'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd(f"show ip{ip_ver} route {prefix} json")
+    json_data = json.loads(output)
+    return json_data.get(prefix, [])
+
+
+def _route_tag_by_distance(router, prefix, ipv6=False):
+    """Return dict mapping distance -> tag for RIB entries of prefix.
+
+    Only valid when at most one entry exists per distance value.  When
+    multiple entries share the same distance (different tags), use
+    _route_nexthop_tags() instead.
+    """
+    return {
+        e.get("distance", 0): e.get("tag", 0)
+        for e in _route_entries(router, prefix, ipv6)
+    }
+
+
+def _route_nexthop_tags(router, prefix, ipv6=False):
+    """Return set of (nexthop_ip, tag) tuples from RIB entries for prefix.
+
+    Iterates all route entries and all nexthops within each entry,
+    pairing each nexthop IP with the route-entry level tag.
+    """
+    result = set()
+    for entry in _route_entries(router, prefix, ipv6):
+        tag = entry.get("tag", 0)
+        for nh in entry.get("nexthops", []):
+            ip = nh.get("ip", "")
+            if ip:
+                result.add((ip, tag))
+    return result
+
+
+def _running_config_routes(router, prefix, ipv6=False):
+    """Return static-route lines for prefix from 'show running-config'."""
+    ip_ver = "v6" if ipv6 else ""
+    output = router.vtysh_cmd("show running-config")
+    keyword = f"ip{ip_ver} route {prefix}"
+    return [l.strip() for l in output.splitlines() if keyword in l]
+
+
+def _check_rib_tags(router, prefix, expected, ipv6=False):
+    """Return None when {distance: tag} map equals expected, else actual."""
+    actual = _route_tag_by_distance(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _check_running(router, prefix, expected_lines, ipv6=False):
+    """Return None when running-config lines equal expected (as set), else actual."""
+    actual = set(_running_config_routes(router, prefix, ipv6))
+    return None if actual == set(expected_lines) else actual
+
+
+def _expect_rib_tags(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_rib_tags, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+def _expect_running(router, prefix, expected_lines, ipv6=False):
+    test_func = functools.partial(
+        _check_running, router, prefix, expected_lines, ipv6
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: basic tag
+# ---------------------------------------------------------------------------
+
+def run_basic_tag(ipv6=False):
+    """
+    Install a route with a tag; verify tag in RIB and running-config.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Verify RIB entry at AD 10 carries tag 100.
+      3. Verify running-config shows 'ip route ... NH1 tag 100 10'.
+      4. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install with tag
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+
+    # Step 2: RIB shows tag 100 at AD 10
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Basic tag [2]: expected {{10: 100}}, got {result}"
+
+    # Step 3: running-config shows tag
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 100 10"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, f"Basic tag [3]: running-config mismatch; got {result}"
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Basic tag [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Basic tag [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_basic_tag_ipv4():
+    "IPv4: route with tag appears with correct tag in RIB and running-config."
+    run_basic_tag(ipv6=False)
+
+
+def test_basic_tag_ipv6():
+    "IPv6: route with tag appears with correct tag in RIB and running-config."
+    run_basic_tag(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: tag per path
+# ---------------------------------------------------------------------------
+
+def run_tag_per_path(ipv6=False):
+    """
+    Two nexthops at different ADs carry independent tags.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, NH2 at AD 20 with tag 200.
+      2. Verify RIB: AD 10 entry has tag 100, AD 20 entry has tag 200.
+      3. Verify running-config shows both lines with correct tags.
+      4. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two paths with different tags
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 20 tag 200\n"
+    )
+
+    # Step 2: each path has its own tag in the RIB
+    result = _expect_rib_tags(r1, prefix, {10: 100, 20: 200}, ipv6)
+    assert result is None, (
+        f"Tag per path [2]: expected {{10:100, 20:200}}, got {result}"
+    )
+
+    # Step 3: running-config shows both lines with correct tags
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 100 10",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 20",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Tag per path [3]: running-config mismatch; got {result}"
+    )
+
+    # Step 4: clean up
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"no ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"no ip{ip_ver} route {prefix} {nh2} 20 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag per path [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag per path [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_per_path_ipv4():
+    "IPv4: two paths at different ADs carry independent tags."
+    run_tag_per_path(ipv6=False)
+
+
+def test_tag_per_path_ipv6():
+    "IPv6: two paths at different ADs carry independent tags."
+    run_tag_per_path(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: tag change
+# ---------------------------------------------------------------------------
+
+def run_tag_change(ipv6=False):
+    """
+    Changing the tag on an existing path updates the RIB and running-config.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure with tag 200 (same nexthop, same AD).
+      3. Verify RIB shows tag 200; old tag 100 is gone.
+      4. Verify running-config shows 'tag 200', not 'tag 100'.
+      5. Clean up.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install with tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: reconfigure with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 200\n"
+    )
+
+    # Step 3: RIB shows tag 200
+    result = _expect_rib_tags(r1, prefix, {10: 200}, ipv6)
+    assert result is None, (
+        f"Tag change [3]: expected {{10:200}}, got {result}"
+    )
+
+    # Step 4: running-config shows tag 200, not tag 100
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 10"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag change [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_change_ipv4():
+    "IPv4: changing the tag on a path updates RIB and running-config."
+    run_tag_change(ipv6=False)
+
+
+def test_tag_change_ipv6():
+    "IPv6: changing the tag on a path updates RIB and running-config."
+    run_tag_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: tag with AD change
+# ---------------------------------------------------------------------------
+
+def run_tag_with_ad_change(ipv6=False):
+    """
+    Moving a nexthop to a new AD with a new tag leaves exactly one entry.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100.
+      2. Reconfigure NH1 at AD 20 with tag 200 (single command; move logic
+         removes the old entry automatically).
+      3. Verify RIB has only AD 20 with tag 200; AD 10 entry is gone.
+      4. Verify running-config shows exactly 'ip route ... NH1 tag 200 20'.
+      5. Clean up; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: install at AD 10, tag 100
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {10: 100}, ipv6)
+    assert result is None, f"Tag+AD change [1]: expected {{10:100}}, got {result}"
+
+    # Step 2: move to AD 20 with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nip{ip_ver} route {prefix} {nh1} 20 tag 200\n"
+    )
+
+    # Step 3: only AD 20 with tag 200 in RIB
+    result = _expect_rib_tags(r1, prefix, {20: 200}, ipv6)
+    assert result is None, (
+        f"Tag+AD change [3]: expected {{20:200}}, stale AD 10 present or tag wrong; got {result}"
+    )
+
+    # Step 4: running-config shows exactly one entry at (AD 20, tag 200)
+    expected_line = f"ip{ip_ver} route {prefix} {nh1} tag 200 20"
+    result = _expect_running(r1, prefix, [expected_line], ipv6)
+    assert result is None, (
+        f"Tag+AD change [4]: running-config mismatch; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 20 tag 200\n"
+    )
+    result = _expect_rib_tags(r1, prefix, {}, ipv6)
+    assert result is None, f"Tag+AD change [cleanup]: RIB not empty; got {result}"
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Tag+AD change [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_tag_with_ad_change_ipv4():
+    "IPv4: nexthop moved to new AD with new tag leaves exactly one RIB/config entry."
+    run_tag_with_ad_change(ipv6=False)
+
+
+def test_tag_with_ad_change_ipv6():
+    "IPv6: nexthop moved to new AD with new tag leaves exactly one RIB/config entry."
+    run_tag_with_ad_change(ipv6=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for same-AD tests
+# ---------------------------------------------------------------------------
+
+def _check_nexthop_tags(router, prefix, expected, ipv6=False):
+    """Return None when (nexthop_ip, tag) set equals expected, else actual."""
+    actual = _route_nexthop_tags(router, prefix, ipv6)
+    return None if actual == expected else actual
+
+
+def _expect_nexthop_tags(router, prefix, expected, ipv6=False):
+    test_func = functools.partial(_check_nexthop_tags, router, prefix, expected, ipv6)
+    _, result = topotest.run_and_expect(test_func, None, count=15, wait=1)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: same AD, different tag
+# ---------------------------------------------------------------------------
+
+def run_same_ad_different_tag(ipv6=False):
+    """
+    Two nexthops at the same AD and metric go into one path-list (keyed by
+    (distance, metric)).  The path tag is the last-configured value; both
+    nexthops form an ECMP group.  Removing one nexthop does not affect the other.
+
+    Steps:
+      1. Install NH1 at AD 10 with tag 100, then NH2 at AD 10 with tag 200.
+         Both land in path-list[distance=10, metric=0].  Tag becomes 200 (last command).
+      2. Verify running-config shows both NHs with tag 200.
+      3. Verify RIB has both NHs as ECMP, each with tag 200.
+      4. Remove NH1; verify NH2 survives in config and RIB with tag 200.
+      5. Clean up NH2; verify RIB and running-config are empty.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    ip_ver = "v6" if ipv6 else ""
+    nh1 = NH1_V6 if ipv6 else NH1_V4
+    nh2 = NH2_V6 if ipv6 else NH2_V4
+    prefix = PREFIX_V6 if ipv6 else PREFIX_V4
+
+    # Step 1: two nexthops at same AD, different tags; last tag (200) wins
+    r1.vtysh_multicmd(
+        f"configure\n"
+        f"ip{ip_ver} route {prefix} {nh1} 10 tag 100\n"
+        f"ip{ip_ver} route {prefix} {nh2} 10 tag 200\n"
+    )
+
+    # Step 2: running-config shows both NHs under one path with tag 200
+    result = _expect_running(
+        r1, prefix,
+        [
+            f"ip{ip_ver} route {prefix} {nh1} tag 200 10",
+            f"ip{ip_ver} route {prefix} {nh2} tag 200 10",
+        ],
+        ipv6,
+    )
+    assert result is None, (
+        f"Same-AD diff-tag [2]: running-config mismatch; got {result}"
+    )
+
+    # Step 3: RIB shows both NHs as ECMP with tag 200
+    result = _expect_nexthop_tags(r1, prefix, {(nh1, 200), (nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [3]: expected ECMP {{(NH1,200),(NH2,200)}}; got {result}"
+    )
+
+    # Step 4: remove NH1; NH2 config and RIB entry survive with tag 200
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh1} 10\n"
+    )
+    result = _expect_running(
+        r1, prefix,
+        [f"ip{ip_ver} route {prefix} {nh2} tag 200 10"],
+        ipv6,
+    )
+    assert result is None, (
+        f"Same-AD diff-tag [4]: NH2 config gone after removing NH1; got {result}"
+    )
+    result = _expect_nexthop_tags(r1, prefix, {(nh2, 200)}, ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [4]: NH2 not in RIB after removing NH1; got {result}"
+    )
+
+    # Step 5: clean up
+    r1.vtysh_multicmd(
+        f"configure\nno ip{ip_ver} route {prefix} {nh2} 10\n"
+    )
+    result = _expect_nexthop_tags(r1, prefix, set(), ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [cleanup]: RIB not empty; got {result}"
+    )
+    result = _expect_running(r1, prefix, [], ipv6)
+    assert result is None, (
+        f"Same-AD diff-tag [cleanup]: stale running-config entry; got {result}"
+    )
+
+
+def test_same_ad_different_tag_ipv4():
+    "IPv4: two nexthops at same AD share one path-list; removing one leaves the other intact."
+    run_same_ad_different_tag(ipv6=False)
+
+
+def test_same_ad_different_tag_ipv6():
+    "IPv6: two nexthops at same AD share one path-list; removing one leaves the other intact."
+    run_same_ad_different_tag(ipv6=True)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -63,6 +63,12 @@ module frr-staticd {
      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2026-03-21 {
+    description
+      "Add 'metric' as a path-list key alongside table-id and distance.";
+    reference "FRRouting";
+  }
+
   revision 2026-01-23 {
     description
       "Augments the nexthop container with a 'weight' leaf.";
@@ -85,7 +91,7 @@ module frr-staticd {
     description
       "Grouping for staticd prefix attributes.";
     list path-list {
-      key "table-id distance";
+      key "table-id distance metric";
       description
         "List of paths associated with a staticd prefix.";
       leaf table-id {
@@ -98,6 +104,12 @@ module frr-staticd {
         type frr-rt:administrative-distance;
         description
           "Admin distance associated with this route.";
+      }
+
+      leaf metric {
+        type uint32;
+        description
+          "Route metric.";
       }
 
       leaf tag {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1553,7 +1553,8 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    re->distance != dplane_ctx_get_old_distance(ctx)) {
+			    (re->distance != dplane_ctx_get_old_distance(ctx) ||
+			     re->metric != dplane_ctx_get_old_metric(ctx))) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_old_metric(ctx)) {
@@ -1579,7 +1580,8 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 			 * kernel routes.
 			 */
 			if (re->type == ZEBRA_ROUTE_STATIC && !async &&
-			    re->distance != dplane_ctx_get_distance(ctx)) {
+			    (re->distance != dplane_ctx_get_distance(ctx) ||
+			     re->metric != dplane_ctx_get_metric(ctx))) {
 				result = false;
 			} else if (re->type == ZEBRA_ROUTE_KERNEL &&
 				   re->metric != dplane_ctx_get_metric(ctx)) {
@@ -1632,13 +1634,12 @@ static bool rib_compare_routes(const struct route_entry *re1, const struct route
 	if (re1->instance != re2->instance)
 		return false;
 
-	if (re1->type == ZEBRA_ROUTE_KERNEL) {
-		if (re1->metric != re2->metric)
-			return false;
+	if ((re1->type == ZEBRA_ROUTE_KERNEL || re1->type == ZEBRA_ROUTE_STATIC) &&
+	    re1->metric != re2->metric)
+		return false;
 
-		if (!replace)
-			return false;
-	}
+	if (re1->type == ZEBRA_ROUTE_KERNEL && !replace)
+		return false;
 
 	if (CHECK_FLAG(re1->flags, ZEBRA_FLAG_RR_USE_DISTANCE) &&
 	    re1->distance != re2->distance)
@@ -2892,7 +2893,7 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 		    ere->re->distance != re->distance)
 			continue;
 
-		if (re->type == ZEBRA_ROUTE_KERNEL &&
+		if ((re->type == ZEBRA_ROUTE_KERNEL || re->type == ZEBRA_ROUTE_STATIC) &&
 		    re->metric != ere->re->metric)
 			continue;
 		if ((re->type == ZEBRA_ROUTE_CONNECT ||


### PR DESCRIPTION
Extend static routes to support a per-route metric in addition to administrative distance,
following the admin distance model in both staticd and zebra.

Changes include separate commits for zebra, staticd, doc, and topotests. Please see
the individual commits for details.