### PR TITLE
ospfd: implement rfc 4222 rec 2 neighbor inactivity timer

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -573,6 +573,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, opaque_capable);
 	UNSET_IF_PARAM(oip, keychain_name);
 	UNSET_IF_PARAM(oip, nbr_filter_name);
+	UNSET_IF_PARAM(oip, dead_timer_any);
 
 	oip->auth_crypt = list_new();
 
@@ -582,6 +583,9 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	oip->ptp_dmvpn = 0;
 	oip->p2mp_delay_reflood = OSPF_P2MP_DELAY_REFLOOD_DEFAULT;
 	oip->opaque_capable = OSPF_OPAQUE_CAPABLE_DEFAULT;
+	/* RFC4222 timers */
+	oip->dead_timer_any = false;
+
 
 	return oip;
 }
@@ -630,7 +634,9 @@ void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 	    !OSPF_IF_PARAM_CONFIGURED(oip, prefix_suppression) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, keychain_name) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, nbr_filter_name) &&
-	    listcount(oip->auth_crypt) == 0) {
+	    !OSPF_IF_PARAM_CONFIGURED(oip, dead_timer_any) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_ospf_all) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, dscp_low_control) && listcount(oip->auth_crypt) == 0) {
 		ospf_del_if_params(ifp, oip);
 		rn->info = NULL;
 		route_unlock_node(rn);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -574,6 +574,8 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, keychain_name);
 	UNSET_IF_PARAM(oip, nbr_filter_name);
 	UNSET_IF_PARAM(oip, dead_timer_any);
+	UNSET_IF_PARAM(oip, dscp_ospf_all);
+	UNSET_IF_PARAM(oip, dscp_low_control);
 
 	oip->auth_crypt = list_new();
 
@@ -585,8 +587,9 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	oip->opaque_capable = OSPF_OPAQUE_CAPABLE_DEFAULT;
 	/* RFC4222 timers */
 	oip->dead_timer_any = false;
-
-
+	/* RFC4222 dscp Priority */
+	oip->dscp_ospf_all = IPTOS_PREC_INTERNETCONTROL >> 2;	 /* upper 6 bits */
+	oip->dscp_low_control = IPTOS_PREC_INTERNETCONTROL >> 2; /* Default feature is off */
 	return oip;
 }
 
@@ -622,14 +625,10 @@ void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 	    !OSPF_IF_PARAM_CONFIGURED(oip, retransmit_interval) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, retransmit_window) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, passive_interface) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, v_hello) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, fast_hello) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, v_wait) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, priority) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, type) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, auth_simple) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, auth_type) &&
-	    !OSPF_IF_PARAM_CONFIGURED(oip, if_area) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, v_hello) && !OSPF_IF_PARAM_CONFIGURED(oip, fast_hello) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, v_wait) && !OSPF_IF_PARAM_CONFIGURED(oip, priority) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, type) && !OSPF_IF_PARAM_CONFIGURED(oip, auth_simple) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, auth_type) && !OSPF_IF_PARAM_CONFIGURED(oip, if_area) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, opaque_capable) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, prefix_suppression) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, keychain_name) &&
@@ -749,6 +748,8 @@ int ospf_if_new_hook(struct interface *ifp)
 	IF_DEF_PARAMS(ifp)->opaque_capable = OSPF_OPAQUE_CAPABLE_DEFAULT;
 
 	IF_DEF_PARAMS(ifp)->prefix_suppression = OSPF_PREFIX_SUPPRESSION_DEFAULT;
+
+	/* RFC4222 parameters intentionally left out here. */
 
 	rc = ospf_opaque_new_if(ifp);
 	return rc;

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -130,6 +130,9 @@ struct ospf_if_params {
 
 	/* Name of prefix-list name for packet source address filtering. */
 	DECLARE_IF_PARAM(char *, nbr_filter_name);
+	/* RFC4222 Inactivity */
+	DECLARE_IF_PARAM(bool,
+			 dead_timer_any); /* when true, All recived packets reset inactivity */
 };
 
 enum { MEMBER_ALLROUTERS = 0,

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -133,6 +133,9 @@ struct ospf_if_params {
 	/* RFC4222 Inactivity */
 	DECLARE_IF_PARAM(bool,
 			 dead_timer_any); /* when true, All recived packets reset inactivity */
+	/* RFC4222 Priority markings */
+	DECLARE_IF_PARAM(uint8_t, dscp_ospf_all);    /* 0–63 */
+	DECLARE_IF_PARAM(uint8_t, dscp_low_control); /* 0–63 */
 };
 
 enum { MEMBER_ALLROUTERS = 0,

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -94,6 +94,7 @@ struct ospf_neighbor *ospf_nbr_new(struct ospf_interface *oi)
 	nbr->gr_helper_info.helper_exit_reason = OSPF_GR_HELPER_EXIT_NONE;
 	nbr->gr_helper_info.gr_restart_reason = OSPF_GR_UNKNOWN_RESTART;
 
+	nbr->dead_timer_resets = 0; /* rfc 4222 rec 2 */
 	return nbr;
 }
 

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -74,7 +74,7 @@ struct ospf_neighbor {
 	const char *last_regress_str;    /* Event which last regressed NSM */
 	uint32_t state_change;		 /* NSM state change counter       */
 	uint32_t ls_rxmt_lsa;		 /* Number of LSAs retransmitted.  */
-	uint64_t dead_timer_resets;  /* Number of times dead-timer was reset RFC4222 rec 2*/
+	uint64_t dead_timer_resets;	 /* Number of times dead-timer was reset RFC4222 rec 2*/
 
 	/* BFD information */
 	struct bfd_session_params *bfd_session;

--- a/ospfd/ospf_neighbor.h
+++ b/ospfd/ospf_neighbor.h
@@ -74,6 +74,7 @@ struct ospf_neighbor {
 	const char *last_regress_str;    /* Event which last regressed NSM */
 	uint32_t state_change;		 /* NSM state change counter       */
 	uint32_t ls_rxmt_lsa;		 /* Number of LSAs retransmitted.  */
+	uint64_t dead_timer_resets;  /* Number of times dead-timer was reset RFC4222 rec 2*/
 
 	/* BFD information */
 	struct bfd_session_params *bfd_session;

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -70,6 +70,17 @@ static void ospf_inactivity_timer(struct event *event)
 				  nbr->v_inactivity);
 	}
 }
+/* RFC4222 */
+void ospf_nsm_restart_inactivity_timer(struct ospf_neighbor *nbr)
+{
+	if (!nbr)
+		return;
+
+	/* Start or Restart Inactivity Timer. */
+	event_cancel(&nbr->t_inactivity);
+
+	OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer, nbr->v_inactivity);
+}
 
 static void ospf_db_desc_timer(struct event *event)
 {

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -52,6 +52,7 @@
 	event_execute(master, ospf_nsm_event, (N), (E), NULL)
 
 /* Prototypes. */
+extern void ospf_nsm_restart_inactivity_timer(struct ospf_neighbor *nbr);
 extern void ospf_nsm_event(struct event *e);
 extern void ospf_check_nbr_loading(struct ospf_neighbor *nbr);
 extern int ospf_db_summary_isempty(struct ospf_neighbor *nbr);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -296,6 +296,37 @@ void ospf_ls_req_event(struct ospf_neighbor *nbr)
 	event_add_event(master, ospf_ls_req_timer, nbr, 0, &nbr->t_ls_req);
 }
 
+static void ospf_maybe_restart_inactivity(struct ospf_interface *oi, struct ospf_neighbor *nbr,
+					  const struct ip *iph)
+{
+	in_addr_t dst;
+
+	if (!nbr)
+		return;
+
+	/* Only apply when configured */
+	if (!OSPF_IF_PARAM(oi, dead_timer_any))
+		return;
+
+	/* Only once the neighbor is at or beyond 2-Way */
+	if (nbr->state < NSM_TwoWay)
+		return;
+
+	dst = ntohl(iph->ip_dst.s_addr);
+
+	/* Any unicast OSPF packet */
+	bool is_unicast = !IN_MULTICAST(dst);
+
+	/* Any OSPF packet to AllSPFRouters over a point-to-point link */
+	bool is_p2p_allspf = (oi->type == OSPF_IFTYPE_POINTOPOINT &&
+			      dst == OSPF_ALLSPFROUTERS); /* 224.0.0.5 in host order */
+
+	if (is_unicast || is_p2p_allspf) {
+		ospf_nsm_restart_inactivity_timer(nbr);
+		nbr->dead_timer_resets++;
+	}
+}
+
 /*
  * OSPF neighbor link state retransmission timer handler. Unicast
  * unacknowledged LSAs to the neighbors.
@@ -1228,6 +1259,11 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 			lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 			ntohl(dd->dd_seqnum), nbr->dd_seqnum);
 
+	/*
+	 * RFC4222: reset inactivity timer on any OSPF unicast packet
+	 * or any AllSPFRouters packet over a point-to-point link.
+	 */
+	ospf_maybe_restart_inactivity(oi, nbr, iph);
 	/* Process DD packet by neighbor status. */
 	switch (nbr->state) {
 	case NSM_Down:
@@ -1474,6 +1510,11 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 		return;
 	}
 
+	/*
+	 * RFC4222: reset inactivity timer on any OSPF unicast packet
+	 * or any AllSPFRouters packet over a point-to-point link.
+	 */
+	ospf_maybe_restart_inactivity(oi, nbr, iph);
 	/* Send Link State Update for ALL requested LSAs. */
 	ls_upd = list_new();
 	length = OSPF_HEADER_SIZE + OSPF_LS_UPD_MIN_SIZE;
@@ -1718,6 +1759,11 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 					   NULL));
 		return;
 	}
+	/*
+	 * RFC4222: reset inactivity timer on any OSPF unicast packet
+	 * or any AllSPFRouters packet over a point-to-point link.
+	 */
+	ospf_maybe_restart_inactivity(oi, nbr, iph);
 
 	/* Get list of LSAs from Link State Update packet. - Also performs
 	 * Stages 1 (validate LSA checksum) and 2 (check for LSA consistent
@@ -2107,6 +2153,12 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 					   NULL));
 		return;
 	}
+	/*
+	 * RFC4222: reset inactivity timer on any OSPF unicast packet
+	 * or any AllSPFRouters packet over a point-to-point link.
+	 */
+	ospf_maybe_restart_inactivity(oi, nbr, iph);
+
 
 	while (size >= OSPF_LSA_HEADER_SIZE) {
 		struct ospf_lsa *lsa, *lsr;

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -416,6 +416,34 @@ void ospf_ls_ack_delayed_timer(struct event *event)
 		ospf_ls_ack_send_delayed(oi);
 }
 
+static inline uint8_t ospf_tos_for_type(struct ospf_interface *oi, uint8_t type)
+{
+	uint8_t dscp;
+
+	switch (type) {
+	case OSPF_MSG_HELLO:
+	case OSPF_MSG_LS_ACK:
+		/* Always highest priority */
+		dscp = OSPF_IF_PARAM(oi, dscp_ospf_all);
+		break;
+
+	case OSPF_MSG_DB_DESC:
+	case OSPF_MSG_LS_REQ:
+	case OSPF_MSG_LS_UPD:
+		/* Bulk control traffic: low control */
+		dscp = OSPF_IF_PARAM(oi, dscp_low_control);
+		break;
+
+	default:
+		dscp = OSPF_IF_PARAM(oi, dscp_low_control);
+		break;
+	}
+
+	dscp &= 0x3f;		     /* clamp to 6 bits */
+	return (uint8_t)(dscp << 2); /* DSCP in bits 7..2, ECN = 0 */
+}
+
+
 #ifdef WANT_OSPF_WRITE_FRAGMENT
 static void ospf_write_frags(int fd, struct ospf_packet *op, struct ip *iph,
 			     struct msghdr *msg, unsigned int maxdatasize,
@@ -593,7 +621,8 @@ static void ospf_write(struct event *event)
 					overflow ip_hl.. */
 
 		iph.ip_v = IPVERSION;
-		iph.ip_tos = IPTOS_PREC_INTERNETCONTROL;
+		/* RFC4222 allow Hellos to have higher priority */
+		iph.ip_tos = ospf_tos_for_type(oi, type);
 		iph.ip_len = (iph.ip_hl << OSPF_WRITE_IPHL_SHIFT) + op->length;
 
 #if defined(__DragonFly__)

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3388,6 +3388,59 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 	return CMD_SUCCESS;
 }
 
+/* RFC4222 DSCP: 'all' (Hello/Ack + default) and 'low-control' override */
+DEFPY(ospf_if_dscp,
+      ospf_if_dscp_cmd,
+      "[no$no] ip ospf dscp <all|low-control>$which [(0-63)$value]",
+      NO_STR
+      IP_STR
+      OSPF_STR
+      "Set DSCP for OSPF control packets\n"    /* dscp */
+      "DSCP used for all OSPF control packets (Hellos, Acks, and others when low-control not set)\n" /* all */
+      "DSCP used for lower-priority control packets (DB-Desc, LS-Req, LSUs)\n"   /* low-control */
+      "DSCP value (0-63)\n") /* (0-63)$value */
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct ospf_if_params *params;
+
+	params = IF_DEF_PARAMS(ifp);
+	if (!params)
+		return CMD_WARNING;
+
+	/* Normalize: if no keyword provided, treat as 'all' for backward-ish usage */
+	if (!which)
+		which = "all";
+
+	if (no) {
+		if (!strcmp(which, "all")) {
+			/* Reset to default: Network Control (CS6 = 48) */
+			UNSET_IF_PARAM(params, dscp_ospf_all);
+			params->dscp_ospf_all = IPTOS_PREC_INTERNETCONTROL >> 2;
+		} else if (!strcmp(which, "low-control")) {
+			/* Clear explicit low-control override; fall back to 'all' DSCP */
+			UNSET_IF_PARAM(params, dscp_low_control);
+			params->dscp_low_control = params->dscp_ospf_all;
+		}
+		return CMD_SUCCESS;
+	}
+
+	/* Non-no case: must have a value */
+	if (!value) {
+		vty_out(vty, "%% DSCP value required\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (!strcmp(which, "all")) {
+		params->dscp_ospf_all = value;
+		SET_IF_PARAM(params, dscp_ospf_all);
+	} else if (!strcmp(which, "low-control")) {
+		params->dscp_low_control = value;
+		SET_IF_PARAM(params, dscp_low_control);
+	}
+
+	return CMD_SUCCESS;
+}
+
 /* RFC4222 any packet sets dead-timer inactivity*/
 DEFPY (ospf_dead_timer_any_control,
 	     ospf_dead_timer_any_control_cmd,
@@ -3412,12 +3465,10 @@ DEFPY (ospf_dead_timer_any_control,
 	} else {
 		SET_IF_PARAM(params, dead_timer_any);
 		params->dead_timer_any = true; /* RFC4222 mode */
-					       /* Uncomment when merged with RFC4222 Rec 1 */
 	}
 
 	return CMD_SUCCESS;
 }
-
 
 DEFUN (show_ip_ospf,
        show_ip_ospf_cmd,
@@ -12334,6 +12385,13 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 						&rn->p.u.prefix4);
 				vty_out(vty, "\n");
 			}
+			/* RFC4222 DSCP knobs */
+			if (OSPF_IF_PARAM_CONFIGURED(params, dscp_ospf_all))
+				vty_out(vty, " ip ospf dscp all %u\n", params->dscp_ospf_all);
+			if (OSPF_IF_PARAM_CONFIGURED(params, dscp_low_control))
+				vty_out(vty, " ip ospf dscp low-control %u\n",
+					params->dscp_low_control);
+
 
 			/* Hello Graceful-Restart Delay print. */
 			if (OSPF_IF_PARAM_CONFIGURED(params,
@@ -13322,6 +13380,8 @@ static void ospf_vty_if_init(void)
 
 	/* RFC4222 for control packets*/
 	install_element(INTERFACE_NODE, &ospf_dead_timer_any_control_cmd);
+	/* RFC4222 DSCP settings for control packets*/
+	install_element(INTERFACE_NODE, &ospf_if_dscp_cmd);
 
 	/* These commands are compatibitliy for previous version. */
 	install_element(INTERFACE_NODE, &ospf_authentication_key_cmd);


### PR DESCRIPTION
RFC 4222 Recommendation 2: When packet prioritization
isn’t feasible, refresh the OSPF neighbor inactivity
timer upon receipt of any valid OSPF unicast packet, or
any OSPF packet sent to AllSPFRouters on a
point-to-point link (not just Hellos), to avoid
unnecessary adjacency drops under congestion. This
extends the adjacency on low-speed links where Hellos
might be delayed or blocked by other control traffic.

Signed-off-by: Don Fedyk <dfedyk@labn.net>