### PR TITLE
bgpd: initialise nh_flag attribute

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1440,9 +1440,10 @@ leak_update(struct bgp *to_bgp, struct bgp_dest *bn,
 		new->extra->vrfleak->nexthop_orig = *nexthop_orig;
 
 	if (leak_update_nexthop_valid(to_bgp, bn, new_attr, afi, safi,
-				      source_bpi, new, bgp_orig, p, debug))
+				      source_bpi, new, bgp_orig, p, debug)) {
 		bgp_path_info_set_flag(bn, new, BGP_PATH_VALID);
-	else
+		SET_FLAG(new->attr->nh_flags, BGP_ATTR_NH_VALID);
+	} else
 		bgp_path_info_unset_flag(bn, new, BGP_PATH_VALID);
 
 	bgp_path_info_add(bn, new);


### PR DESCRIPTION
in "leak_update" function
nh_flag is not initialized when nexthop is valid at route creation.

Original PR21498 by fdumontet6WIND
