### PR TITLE
zebra: fix wrong comparision for nexthop

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -461,7 +461,7 @@ bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh
 	if (nh1 == nh2)
 		return true;
 
-	return nexthop_cmp_internal(nh1, nh2, true, false);
+	return (nexthop_cmp_internal(nh1, nh2, true, false) == 0);
 }
 
 bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2)


### PR DESCRIPTION
By accident, i found the "same" field in log of the nexthop was actually opposite. Regardless of whether it is active or not, "same" field should be true.

Before:
```
ZEBRA: [M8H8E-HFGSQ] zebra_nhg_nexthop_compare: 3.3.3.3/32 Comparing via 192.168.0.1, enp2s0(1) ACTIVE: 1 to old: via 192.168.0.1, enp2s0(3) ACTIVE: 1 nexthop same: 0
```

After:
```
ZEBRA: [M8H8E-HFGSQ] zebra_nhg_nexthop_compare: 3.3.3.3/32 Comparing via 192.168.0.1, enp2s0(1) ACTIVE: 1 to old: via 192.168.0.1, enp2s0(3) ACTIVE: 1 nexthop same: 1
```

And this commit should affect the scenarios where `nexthop_same_no_ifindex` is introduced.

Original PR21503 by anlancs
