### PR TITLE
zebra: Fix incorrect update of 'nhe_received' in route_entry_update_nhe()

### DIFF
--- a/tests/topotests/zebra_received_nhe_kept/test_zebra_received_nhe_kept.py
+++ b/tests/topotests/zebra_received_nhe_kept/test_zebra_received_nhe_kept.py
@@ -66,7 +66,7 @@ def test_zebra_received_nhe_kept():
     r1 = tgen.gears["r1"]
 
     @retry(retry_timeout=30, retry_sleep=0.25)
-    def _check_zebra_routes():
+    def _check_zebra_routes(**kwargs):
         # Get the route information
         route_info = r1.vtysh_cmd("show ip route json")
         route_json = json.loads(route_info)
@@ -93,10 +93,25 @@ def test_zebra_received_nhe_kept():
             ), f"Route {prefix} has different NHG ID"
 
         # Get the NHG information
+        # Each route holds 2 refs to the NHG: one for re->nhe and one for
+        # re->nhe_received. With 5 routes, the expected refcount is 10.
         logger.info("Verify NHG {} has refcount of 10".format(nhg_id))
         nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
         nhg_json = json.loads(nhg_info)
         assert nhg_json[str(nhg_id)]["refCount"] == 10, "NHG refcount is not 10"
+
+        # Verify that receivedNexthopGroupId exists for all routes.
+        #
+        # Note: The current implementation updates nhe_received during route
+        # modification (including route resolution), so receivedNexthopGroupId
+        # may equal nexthopGroupId after resolution. This is expected behavior.
+        # We only verify that receivedNexthopGroupId exists and is shared correctly.
+        for i in range(1, 6):
+            prefix = f"10.0.0.{i}/32"
+            route = route_json[prefix][0]
+            assert (
+                "receivedNexthopGroupId" in route
+            ), f"Route {prefix} missing receivedNexthopGroupId"
 
     assert not _check_zebra_routes()
 
@@ -151,15 +166,16 @@ def test_zebra_received_nhe_kept_remove_routes():
             nhg_id = route[0].get("receivedNexthopGroupId")
             break
 
-    step("Verify NHG {} has refcount of 2".format(nhg_id))
+    step("Verify NHG {} has refcount of 4".format(nhg_id))
 
     # Get the NHG information
-    def check_nhg_refcount_4():
+    # 2 routes remaining * 2 refs each (re->nhe + re->nhe_received) = 4
+    def check_nhg_refcount_2():
         nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
         nhg_json = json.loads(nhg_info)
         return nhg_json.get(str(nhg_id), {}).get("refCount")
 
-    _, result = topotest.run_and_expect(check_nhg_refcount_4, 4, count=30, wait=1)
+    _, result = topotest.run_and_expect(check_nhg_refcount_2, 4, count=30, wait=1)
     assert result == 4, "NHG refcount is not 4"
 
 
@@ -223,15 +239,16 @@ def test_zebra_received_nhe_kept_add_routes():
             route["receivedNexthopGroupId"] == nhg_id
         ), f"Route {prefix} has different NHG ID"
 
-    step("Verify NHG {} has refcount of 10".format(nhg_id))
+    step("Verify NHG {} has refcount of 20".format(nhg_id))
 
     # Get the NHG information
-    def check_nhg_refcount_20():
+    # 10 routes * 2 refs each (re->nhe + re->nhe_received) = 20
+    def check_nhg_refcount_10():
         nhg_info = r1.vtysh_cmd("show nexthop-group rib {} json".format(nhg_id))
         nhg_json = json.loads(nhg_info)
         return nhg_json.get(str(nhg_id), {}).get("refCount")
 
-    _, result = topotest.run_and_expect(check_nhg_refcount_20, 20, count=30, wait=1)
+    _, result = topotest.run_and_expect(check_nhg_refcount_10, 20, count=30, wait=1)
     assert result == 20, "NHG refcount is not 20"
 
 
@@ -293,6 +310,90 @@ def test_zebra_received_nhe_kept_remove_all_routes():
 
     # Verify the specific NHG we looked up is no longer present
     assert result, f"NHG {nhg_id} still exists after removing all routes"
+
+
+def test_zebra_received_nhe_kept_nexthop_change():
+    """Test that receivedNexthopGroupId is properly set when route nexthop changes.
+
+    This test verifies that when a static route's nexthop is explicitly changed by
+    the user (upper protocol), the new route has a valid receivedNexthopGroupId
+    that reflects the new received NHG.
+
+    Note: This is different from route resolution, where zebra internally resolves
+    an unresolved nexthop to a concrete one. During resolution, receivedNexthopGroupId
+    should NOT change - it should keep pointing to the original unresolved NHG.
+    Only when the upper protocol (e.g., user modifying static route) changes the
+    nexthop should receivedNexthopGroupId be updated to the new NHG.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step(
+        "Add route 10.0.0.1/32 via 10.0.0.0 and record original receivedNexthopGroupId"
+    )
+    r1.vtysh_cmd("configure terminal\n ip route 10.0.0.1/32 10.0.0.0\n end")
+
+    def get_received_nhg_id():
+        route_info = r1.vtysh_cmd("show ip route 10.0.0.1/32 json")
+        route_json = json.loads(route_info)
+        if "10.0.0.1/32" not in route_json:
+            return None
+        route = route_json["10.0.0.1/32"][0]
+        return route.get("receivedNexthopGroupId")
+
+    def check_route_has_rcv_id():
+        return get_received_nhg_id() is not None
+
+    _, result = topotest.run_and_expect(check_route_has_rcv_id, True, count=30, wait=1)
+    assert result, "Route 10.0.0.1/32 missing receivedNexthopGroupId"
+    original_rcv_id = get_received_nhg_id()
+    assert (
+        original_rcv_id is not None
+    ), "Route 10.0.0.1/32 missing receivedNexthopGroupId"
+
+    step("Update route 10.0.0.1/32 to use a different nexthop 192.168.1.1")
+    r1.vtysh_cmd(
+        "configure terminal\n"
+        " no ip route 10.0.0.1/32 10.0.0.0\n"
+        " ip route 10.0.0.1/32 192.168.1.1\n"
+        "end"
+    )
+
+    step("Verify new route has valid receivedNexthopGroupId")
+
+    def check_new_route_has_rcv_id():
+        new_id = get_received_nhg_id()
+        return new_id is not None
+
+    _, result = topotest.run_and_expect(
+        check_new_route_has_rcv_id, True, count=30, wait=1
+    )
+    assert result, "Updated route 10.0.0.1/32 missing receivedNexthopGroupId"
+    new_rcv_id = get_received_nhg_id()
+    assert (
+        new_rcv_id is not None and new_rcv_id != original_rcv_id
+    ), "receivedNexthopGroupId should update when route nexthop changes"
+
+    step("Verify old received NHG is removed from rib after route nexthop change")
+
+    def check_old_rcv_nhg_removed():
+        nhg_info = r1.vtysh_cmd("show nexthop-group rib json")
+        nhg_json = json.loads(nhg_info)
+        return str(original_rcv_id) not in nhg_json
+
+    _, result = topotest.run_and_expect(
+        check_old_rcv_nhg_removed, True, count=30, wait=1
+    )
+    assert result, (
+        f"Old received NHG {original_rcv_id} should be removed after "
+        "route nexthop change releases its nhe_received ref"
+    )
+
+    step("Cleanup: remove the test route")
+    r1.vtysh_cmd("configure terminal\n no ip route 10.0.0.1/32 192.168.1.1\n end")
 
 
 if __name__ == "__main__":

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -485,6 +485,17 @@ int route_entry_update_nhe(struct route_entry *re,
 	if (new_nhghe == NULL) {
 		old_nhg = re->nhe;
 
+		/*
+		 * If nhe_received points to the same NHG being deleted,
+		 * decrement its refcount and clear it. This handles the case
+		 * where re->nhe and re->nhe_received point to the same NHG
+		 * (e.g., when route was initially added with the same NHG).
+		 */
+		if (re->nhe_received && re->nhe_received == re->nhe) {
+			zebra_nhg_decrement_ref(re->nhe_received);
+			re->nhe_received = NULL;
+		}
+
 		re->nhe_id = 0;
 		re->nhe_installed_id = 0;
 		re->nhe = NULL;
@@ -504,13 +515,21 @@ done:
 	/* Detach / deref previous nhg */
 
 	if (old_nhg) {
+		/*
+		 * If nhe_received points to the old NHG, update it to
+		 * the new one. This handles the case where nhe_received
+		 * and nhe are the same (e.g., RMAC routes or routes
+		 * before resolution).
+		 *
+		 * Note: If nhe_received points to a different NHG
+		 * (the true original received NHG), it is left untouched.
+		 */
 		if (re->nhe_received == old_nhg) {
 			zebra_nhg_decrement_ref(old_nhg);
+			if (new_nhghe)
+				zebra_nhg_increment_ref(new_nhghe);
+			re->nhe_received = new_nhghe;
 		}
-		if (new_nhghe)
-			zebra_nhg_increment_ref(new_nhghe);
-
-		re->nhe_received = new_nhghe;
 
 		/*
 		 * Return true if we are deleting the previous NHE
@@ -543,9 +562,26 @@ int rib_handle_nhg_replace(struct nhg_hash_entry *old_entry,
 		for (rn = route_top(zrt->table); rn;
 		     rn = srcdest_route_next(rn)) {
 			RNODE_FOREACH_RE_SAFE (rn, re, next) {
-				if (re->nhe && re->nhe == old_entry)
+				if (re->nhe && re->nhe == old_entry) {
+					/*
+					 * If nhe_received points to old_entry,
+					 * migrate it to new_entry before
+					 * route_entry_update_nhe() releases
+					 * old_entry's re->nhe ref. This prevents
+					 * nhe_received from becoming a dangling
+					 * pointer when old_entry is force-freed
+					 * below. nhe_received that already points
+					 * to a different NHG (the true original
+					 * received NHG) is left untouched.
+					 */
+					if (re->nhe_received == old_entry) {
+						zebra_nhg_decrement_ref(old_entry);
+						zebra_nhg_increment_ref(new_entry);
+						re->nhe_received = new_entry;
+					}
 					ret += route_entry_update_nhe(re,
 								      new_entry);
+				}
 			}
 		}
 	}
@@ -2530,6 +2566,11 @@ static void rib_re_nhg_free(struct route_entry *re)
 	} else if (re->nhe && re->nhe->nhg.nexthop)
 		nexthops_free(re->nhe->nhg.nexthop);
 
+	/*
+	 * Clean up nhe_received if it wasn't already cleared by
+	 * route_entry_update_nhe above. This happens when nhe_received
+	 * points to a different NHG than nhe (e.g., after route resolution).
+	 */
 	if (re->nhe_received) {
 		zebra_nhg_decrement_ref(re->nhe_received);
 		re->nhe_received = NULL;


### PR DESCRIPTION
The variable 'nhe_received' is used to store the NHG received from the upper-level protocol.
It should not be updated once it's set during early route processing, as we want to preserve the original one.

Updating it in 'route_entry_update_nhe()' causes the loss of the original NHG.
Let's fix it.

Original PR21104 by GaladrielZhao
