### PR TITLE
zebra: add dplane helpers to provide interface speed

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1102,6 +1102,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_INSTALL:
 	case DPLANE_OP_INTF_UPDATE:
 	case DPLANE_OP_INTF_DELETE:
+	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_TC_QDISC_INSTALL:
 	case DPLANE_OP_TC_QDISC_UNINSTALL:
 	case DPLANE_OP_TC_CLASS_ADD:

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1506,6 +1506,12 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			} else
 				zif_slave_type = ZEBRA_IF_SLAVE_OTHER;
 		}
+		if (startup) {
+			dplane_ctx_set_ifp_speed(ctx, kernel_get_speed(vrf_id, name, NULL));
+			dplane_ctx_set_ifp_speed_set(ctx, true);
+		} else
+			dplane_ctx_set_ifp_speed_set(ctx, false);
+
 		dplane_ctx_set_ifp_zif_slave_type(ctx, zif_slave_type);
 		dplane_ctx_set_ifp_vrf_id(ctx, vrf_id);
 		dplane_ctx_set_ifp_master_ifindex(ctx, master_infindex);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -204,17 +204,6 @@ static int if_zebra_new_hook(struct interface *ifp)
 
 	ifp->info = zebra_if;
 
-	/*
-	 * Some platforms are telling us that the interface is
-	 * up and ready to go.  When we check the speed we
-	 * sometimes get the wrong value.  Wait a couple
-	 * of seconds and ask again.  Hopefully it's all settled
-	 * down upon startup.
-	 */
-	zebra_if->speed_update_count = 0;
-	zebra_if->speed_checked = 0;
-	zebra_if_schedule_speed_update(zebra_if, 15);
-
 	return 0;
 }
 
@@ -2138,6 +2127,17 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 				speed = 0;
 				/* Query initial speed if not provided by dplane */
 				dplane_intf_speed_get(ifp);
+
+				/*
+				 * Some platforms are telling us that the interface is
+				 * up and ready to go.  When we check the speed we
+				 * sometimes get the wrong value.  Wait a couple
+				 * of seconds and ask again.  Hopefully it's all settled
+				 * down upon startup.
+				 */
+				zif->speed_update_count = 0;
+				zif->speed_checked = 0;
+				zebra_if_schedule_speed_update(zif, 15);
 			} else
 				zif->speed_checked++;
 			if_update_state_speed(ifp, speed);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -64,22 +64,40 @@ static const char *if_zebra_data_state(uint8_t state)
 static void if_zebra_speed_update(struct event *event)
 {
 	struct interface *ifp = EVENT_ARG(event);
-	struct zebra_if *zif = ifp->info;
-	uint32_t new_speed;
-	bool changed = false;
-	int error = 0;
 
+	dplane_intf_speed_get(ifp);
+}
+
+static void zebra_if_schedule_speed_update(struct zebra_if *zif, int timeout)
+{
+	event_add_timer(zrouter.master, if_zebra_speed_update, zif->ifp, timeout,
+			&zif->speed_update);
+	event_ignore_late_timer(zif->speed_update);
+}
+
+static void zebra_if_speed_update_ctx(struct zebra_dplane_ctx *ctx, struct interface *ifp)
+{
+	enum zebra_dplane_result dp_res;
+	bool speed_set, changed = false;
+	struct zebra_if *zif;
+	uint32_t new_speed;
+
+	if (!ifp)
+		return;
+
+	zif = ifp->info;
 	zif->speed_checked++;
 
-	new_speed = kernel_get_speed(ifp->vrf->vrf_id, ifp->name, &error);
-
+	dp_res = dplane_ctx_get_status(ctx);
 	/* error may indicate vrf not available or
 	 * interfaces not available.
 	 * note that loopback & virtual interfaces can return 0 as speed
 	 */
-	if (error == INTERFACE_SPEED_ERROR_READ)
+	if (dp_res == ZEBRA_DPLANE_REQUEST_FAILURE)
 		return;
 
+	speed_set = dplane_ctx_get_ifp_speed_set(ctx);
+	new_speed = speed_set ? dplane_ctx_get_ifp_speed(ctx) : 0;
 	if (new_speed != ifp->speed) {
 		zlog_info("%s: %s old speed: %u new speed: %u", __func__,
 			  ifp->name, ifp->speed, new_speed);
@@ -88,7 +106,7 @@ static void if_zebra_speed_update(struct event *event)
 		changed = true;
 	}
 
-	if (changed || error == INTERFACE_SPEED_ERROR_UNKNOWN) {
+	if (changed || !speed_set) {
 #define SPEED_UPDATE_SLEEP_TIME 5
 #define SPEED_UPDATE_COUNT_MAX (4 * 60 / SPEED_UPDATE_SLEEP_TIME)
 		/*
@@ -103,15 +121,42 @@ static void if_zebra_speed_update(struct event *event)
 		 * to not update the system to keep track of that.  This
 		 * is far simpler to just stop trying after 4 minutes
 		 */
-		if (error == INTERFACE_SPEED_ERROR_UNKNOWN &&
-		    zif->speed_update_count == SPEED_UPDATE_COUNT_MAX)
+		if (!speed_set && zif->speed_update_count == SPEED_UPDATE_COUNT_MAX)
 			return;
 
 		zif->speed_update_count++;
-		event_add_timer(zrouter.master, if_zebra_speed_update, ifp,
-				SPEED_UPDATE_SLEEP_TIME, &zif->speed_update);
-		event_ignore_late_timer(zif->speed_update);
+		zebra_if_schedule_speed_update(zif, SPEED_UPDATE_SLEEP_TIME);
 	}
+}
+
+void zebra_if_speed_process(struct zebra_dplane_ctx *ctx)
+{
+	const char *ifname = dplane_ctx_get_ifname(ctx);
+	vrf_id_t vrf_id = dplane_ctx_get_vrf(ctx);
+	uint32_t speed;
+	int error = 0;
+
+	speed = kernel_get_speed(vrf_id, ifname, &error);
+	switch (error) {
+	case 0:
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
+		dplane_ctx_set_ifp_speed(ctx, speed);
+		dplane_ctx_set_ifp_speed_set(ctx, true);
+		return;
+	case INTERFACE_SPEED_ERROR_UNKNOWN:
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
+		dplane_ctx_set_ifp_speed_set(ctx, false);
+		return;
+	case INTERFACE_SPEED_ERROR_READ:
+		/* INTERFACE_SPEED_ERROR_READ: means no device, no vrf */
+		break;
+	default:
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("kernel_get_speed returned an unknown error %u", error);
+		break;
+	}
+
+	dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 
 static void zebra_if_node_destroy(route_table_delegate_t *delegate,
@@ -168,9 +213,7 @@ static int if_zebra_new_hook(struct interface *ifp)
 	 */
 	zebra_if->speed_update_count = 0;
 	zebra_if->speed_checked = 0;
-	event_add_timer(zrouter.master, if_zebra_speed_update, ifp, 15,
-			&zebra_if->speed_update);
-	event_ignore_late_timer(zebra_if->speed_update);
+	zebra_if_schedule_speed_update(zebra_if, 15);
 
 	return 0;
 }
@@ -933,9 +976,7 @@ static void if_handle_bond_speed_change(struct interface *ifp)
 	if (part_of_bond->bond_if) {
 		zif = part_of_bond->bond_if->info;
 
-		if (!event_is_scheduled(zif->speed_update))
-			event_add_timer(zrouter.master, if_zebra_speed_update, part_of_bond->bond_if, 1,
-					&zif->speed_update);
+		zebra_if_schedule_speed_update(zif, 1);
 	}
 }
 
@@ -997,9 +1038,8 @@ void if_up(struct interface *ifp, bool install_connected)
 	if (zif->flags & ZIF_FLAG_EVPN_MH_UPLINK)
 		zebra_evpn_mh_uplink_oper_update(zif);
 
-	event_add_timer(zrouter.master, if_zebra_speed_update, ifp, 0,
-			&zif->speed_update);
-	event_ignore_late_timer(zif->speed_update);
+	event_cancel(&zif->speed_update);
+	dplane_intf_speed_get(ifp);
 
 	if_addr_wakeup(ifp);
 
@@ -2094,8 +2134,12 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			if_update_state_mtu(ifp, mtu);
 			if_update_state_mtu6(ifp, mtu);
 			if_update_state_metric(ifp, 0);
-			if (!speed_set)
-				speed = kernel_get_speed(ifp->vrf->vrf_id, ifp->name, NULL);
+			if (!speed_set) {
+				speed = 0;
+				/* Query initial speed if not provided by dplane */
+				dplane_intf_speed_get(ifp);
+			} else
+				zif->speed_checked++;
 			if_update_state_speed(ifp, speed);
 			ifp->ptm_status = ZEBRA_PTM_STATUS_UNKNOWN;
 			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);
@@ -2200,8 +2244,10 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			if_update_state_mtu(ifp, mtu);
 			if_update_state_mtu6(ifp, mtu);
 			if_update_state_metric(ifp, 0);
-			if (speed_set)
+			if (speed_set) {
+				zif->speed_checked++;
 				if_update_state_speed(ifp, speed);
+			}
 			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);
 
 			/*
@@ -2409,6 +2455,8 @@ void zebra_if_dplane_result(struct zebra_dplane_ctx *ctx)
 			zebra_if_update_ctx(ctx, ifp);
 	} else if (op == DPLANE_OP_INTF_NETCONFIG) {
 		zebra_if_netconf_update_ctx(ctx, ifp, ifindex);
+	} else if (op == DPLANE_OP_INTF_SPEED_GET) {
+		zebra_if_speed_update_ctx(ctx, ifp);
 	}
 }
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2026,8 +2026,8 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		uint32_t mtu;
 		ns_id_t link_nsid;
 		struct zebra_if *zif;
-		bool protodown, protodown_set, startup;
-		uint32_t rc_bitfield;
+		bool protodown, protodown_set, startup, speed_set;
+		uint32_t rc_bitfield, speed;
 		uint8_t old_hw_addr[INTERFACE_HWADDR_MAX];
 		char *desc;
 		uint8_t family;
@@ -2054,6 +2054,8 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		desc = dplane_ctx_get_ifp_desc(ctx);
 		family = dplane_ctx_get_ifp_family(ctx);
 		change_flags = dplane_ctx_get_ifp_change_flags(ctx);
+		speed_set = dplane_ctx_get_ifp_speed_set(ctx);
+		speed = dplane_ctx_get_ifp_speed(ctx);
 
 #ifndef AF_BRIDGE
 		/*
@@ -2092,7 +2094,9 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			if_update_state_mtu(ifp, mtu);
 			if_update_state_mtu6(ifp, mtu);
 			if_update_state_metric(ifp, 0);
-			if_update_state_speed(ifp, kernel_get_speed(ifp, NULL));
+			if (!speed_set)
+				speed = kernel_get_speed(ifp, NULL);
+			if_update_state_speed(ifp, speed);
 			ifp->ptm_status = ZEBRA_PTM_STATUS_UNKNOWN;
 			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);
 
@@ -2196,6 +2200,8 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			if_update_state_mtu(ifp, mtu);
 			if_update_state_mtu6(ifp, mtu);
 			if_update_state_metric(ifp, 0);
+			if (speed_set)
+				if_update_state_speed(ifp, speed);
 			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);
 
 			/*

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -71,7 +71,7 @@ static void if_zebra_speed_update(struct event *event)
 
 	zif->speed_checked++;
 
-	new_speed = kernel_get_speed(ifp, &error);
+	new_speed = kernel_get_speed(ifp->vrf->vrf_id, ifp->name, &error);
 
 	/* error may indicate vrf not available or
 	 * interfaces not available.
@@ -2095,7 +2095,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			if_update_state_mtu6(ifp, mtu);
 			if_update_state_metric(ifp, 0);
 			if (!speed_set)
-				speed = kernel_get_speed(ifp, NULL);
+				speed = kernel_get_speed(ifp->vrf->vrf_id, ifp->name, NULL);
 			if_update_state_speed(ifp, speed);
 			ifp->ptm_status = ZEBRA_PTM_STATUS_UNKNOWN;
 			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -342,6 +342,7 @@ extern void zebra_l2_unmap_slave_from_bond(struct zebra_if *zif);
 extern const char *zebra_protodown_rc_str(uint32_t protodown_rc, char *pd_buf,
 					  uint32_t pd_buf_len);
 void zebra_if_dplane_result(struct zebra_dplane_ctx *ctx);
+void zebra_if_speed_process(struct zebra_dplane_ctx *ctx);
 
 #ifdef HAVE_PROC_NET_DEV
 extern void ifstat_update_proc(void);

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1464,6 +1464,7 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 	case DPLANE_OP_BR_PORT_UPDATE:
 		return FRR_NETLINK_SUCCESS;
 
+	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_IPTABLE_ADD:
 	case DPLANE_OP_IPTABLE_DELETE:
 	case DPLANE_OP_IPSET_ADD:

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1692,6 +1692,7 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		case DPLANE_OP_GRE_SET:
 		case DPLANE_OP_INTF_ADDR_ADD:
 		case DPLANE_OP_INTF_ADDR_DEL:
+		case DPLANE_OP_INTF_SPEED_GET:
 		case DPLANE_OP_STARTUP_STAGE:
 		case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 		case DPLANE_OP_VLAN_INSTALL:

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -77,7 +77,7 @@ extern int mpls_kernel_init(void);
 void kernel_router_init(void);
 void kernel_router_terminate(void);
 
-extern uint32_t kernel_get_speed(struct interface *ifp, int *error);
+extern uint32_t kernel_get_speed(vrf_id_t vrf_id, const char *ifname, int *error);
 extern int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *mroute);
 
 /*

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -23,6 +23,7 @@
 #include "lib_errors.h"
 
 #include "zebra/debug.h"
+#include "zebra/interface.h"
 #include "zebra/rib.h"
 #include "zebra/rt.h"
 #include "zebra/kernel_socket.h"
@@ -383,9 +384,12 @@ extern int kernel_interface_set_master(struct interface *master,
 	return 0;
 }
 
-uint32_t kernel_get_speed(struct interface *ifp, int *error)
+uint32_t kernel_get_speed(vrf_id_t vrf_id, const char *ifname, int *error)
 {
-	return ifp->speed;
+	if (error)
+		*error = INTERFACE_SPEED_ERROR_READ;
+
+	return 0;
 }
 
 int kernel_upd_mac_nh(uint32_t nh_id, struct ipaddr *vtep_ip)

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -649,6 +649,9 @@ static struct zebra_dplane_globals {
 	_Atomic uint32_t dg_intfs_in;
 	_Atomic uint32_t dg_intf_errors;
 
+	_Atomic uint32_t dg_intf_speed_get_in;
+	_Atomic uint32_t dg_intf_speed_get_errors;
+
 	_Atomic uint32_t dg_tcs_in;
 	_Atomic uint32_t dg_tcs_errors;
 
@@ -927,6 +930,7 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 		break;
 	case DPLANE_OP_GRE_SET:
 	case DPLANE_OP_INTF_NETCONFIG:
+	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_STARTUP_STAGE:
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 		break;
@@ -1210,6 +1214,9 @@ const char *dplane_op2str(enum dplane_op_e op)
 		return "INTF_UPDATE";
 	case DPLANE_OP_INTF_DELETE:
 		return "INTF_DELETE";
+
+	case DPLANE_OP_INTF_SPEED_GET:
+		return "INTF_SPEED_GET";
 
 	case DPLANE_OP_TC_QDISC_INSTALL:
 		return "TC_QDISC_INSTALL";
@@ -5555,6 +5562,45 @@ enum zebra_dplane_result dplane_intf_update(const struct interface *ifp)
 }
 
 /*
+ * Enqueue a interface speed query for the dataplane.
+ */
+enum zebra_dplane_result dplane_intf_speed_get(const struct interface *ifp)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	struct zebra_dplane_ctx *ctx = NULL;
+	struct zebra_ns *zns;
+	int ret;
+
+	ctx = dplane_ctx_alloc();
+
+	ctx->zd_op = DPLANE_OP_INTF_SPEED_GET;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
+
+	strlcpy(ctx->zd_ifname, ifp->name, sizeof(ctx->zd_ifname));
+	ctx->zd_ifindex = ifp->ifindex;
+
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
+	dplane_ctx_ns_init(ctx, zns, false);
+
+	ret = dplane_update_enqueue(ctx);
+
+	/* Increment counter */
+	atomic_fetch_add_explicit(&zdplane_info.dg_intf_speed_get_in, 1, memory_order_relaxed);
+
+	if (ret == AOK)
+		result = ZEBRA_DPLANE_REQUEST_QUEUED;
+	else {
+		atomic_fetch_add_explicit(&zdplane_info.dg_intf_speed_get_errors, 1,
+					  memory_order_relaxed);
+		if (ctx)
+			dplane_ctx_free(&ctx);
+	}
+
+	return result;
+}
+
+/*
  * Enqueue vxlan/evpn mac add (or update).
  */
 enum zebra_dplane_result dplane_rem_mac_add(const struct interface *ifp,
@@ -6407,6 +6453,11 @@ int dplane_show_helper(struct vty *vty, bool detailed)
 	vty_out(vty, "Intf change updates:        %" PRIu64 "\n", incoming);
 	vty_out(vty, "Intf change errors:         %" PRIu64 "\n", errs);
 
+	incoming = atomic_load_explicit(&zdplane_info.dg_intf_speed_get_in, memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_intf_speed_get_errors, memory_order_relaxed);
+	vty_out(vty, "Intf speed query:           %" PRIu64 "\n", incoming);
+	vty_out(vty, "Intf speed errors:          %" PRIu64 "\n", errs);
+
 	incoming = atomic_load_explicit(&zdplane_info.dg_macs_in,
 					memory_order_relaxed);
 	errs = atomic_load_explicit(&zdplane_info.dg_mac_errors,
@@ -7050,6 +7101,11 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 			   dplane_ctx_get_ifindex(ctx),
 			   dplane_ctx_intf_is_protodown(ctx));
 		break;
+	case DPLANE_OP_INTF_SPEED_GET:
+		zlog_debug("Dplane intf %s, idx %u, speed %u",
+			   dplane_op2str(dplane_ctx_get_op(ctx)), dplane_ctx_get_ifindex(ctx),
+			   dplane_ctx_get_ifp_speed(ctx));
+		break;
 
 	/* TODO: more detailed log */
 	case DPLANE_OP_TC_QDISC_INSTALL:
@@ -7246,6 +7302,7 @@ static void kernel_dplane_handle_result(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_ADDR_ADD:
 	case DPLANE_OP_INTF_ADDR_DEL:
 	case DPLANE_OP_INTF_NETCONFIG:
+	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_VLAN_INSTALL:
 		break;
 
@@ -7284,6 +7341,13 @@ kernel_dplane_process_ipset_entry(struct zebra_dplane_provider *prov,
 				  struct zebra_dplane_ctx *ctx)
 {
 	zebra_pbr_process_ipset_entry(ctx);
+	dplane_provider_enqueue_out_ctx(prov, ctx);
+}
+
+static void kernel_dplane_process_if_speed(struct zebra_dplane_provider *prov,
+					   struct zebra_dplane_ctx *ctx)
+{
+	zebra_if_speed_process(ctx);
 	dplane_provider_enqueue_out_ctx(prov, ctx);
 }
 
@@ -7345,6 +7409,8 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 			  || dplane_ctx_get_op(ctx)
 				     == DPLANE_OP_IPSET_ENTRY_DELETE))
 			kernel_dplane_process_ipset_entry(prov, ctx);
+		else if (dplane_ctx_get_op(ctx) == DPLANE_OP_INTF_SPEED_GET)
+			kernel_dplane_process_if_speed(prov, ctx);
 		else
 			dplane_ctx_list_add_tail(&work_list, ctx);
 	}

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -239,6 +239,9 @@ struct dplane_intf_info {
 	uint32_t flags;
 	uint32_t change_flags;
 
+	bool speed_set;
+	uint32_t speed;
+
 	bool protodown;
 	bool protodown_set;
 	bool pd_reason_val;
@@ -1824,6 +1827,34 @@ void dplane_ctx_set_ifp_zif_type(struct zebra_dplane_ctx *ctx,
 	DPLANE_CTX_VALID(ctx);
 
 	ctx->u.intf.zif_type = zif_type;
+}
+
+void dplane_ctx_set_ifp_speed_set(struct zebra_dplane_ctx *ctx, bool set)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.speed_set = set;
+}
+
+bool dplane_ctx_get_ifp_speed_set(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.speed_set;
+}
+
+void dplane_ctx_set_ifp_speed(struct zebra_dplane_ctx *ctx, uint32_t speed)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.speed = speed;
+}
+
+uint32_t dplane_ctx_get_ifp_speed(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.speed;
 }
 
 void dplane_ctx_set_ifname(struct zebra_dplane_ctx *ctx, const char *ifname)

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -192,6 +192,7 @@ enum dplane_op_e {
 
 	/* Incoming interface config events */
 	DPLANE_OP_INTF_NETCONFIG,
+	DPLANE_OP_INTF_SPEED_GET,
 
 	/* Interface update */
 	DPLANE_OP_INTF_INSTALL,
@@ -974,6 +975,7 @@ enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
  */
 enum zebra_dplane_result dplane_intf_add(const struct interface *ifp);
 enum zebra_dplane_result dplane_intf_update(const struct interface *ifp);
+enum zebra_dplane_result dplane_intf_speed_get(const struct interface *ifp);
 
 /*
  * Enqueue tc link changes for the dataplane.

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -442,6 +442,10 @@ uint8_t dplane_ctx_get_ifp_family(const struct zebra_dplane_ctx *ctx);
 struct zebra_vxlan_vni_array;
 void dplane_ctx_set_ifp_vxlan_vni_array(struct zebra_dplane_ctx *ctx,
 					struct zebra_vxlan_vni_array *vniarray);
+void dplane_ctx_set_ifp_speed_set(struct zebra_dplane_ctx *ctx, bool set);
+bool dplane_ctx_get_ifp_speed_set(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_ifp_speed(struct zebra_dplane_ctx *ctx, uint32_t speed);
+uint32_t dplane_ctx_get_ifp_speed(const struct zebra_dplane_ctx *ctx);
 
 /*
  * These defines mirror the values for bridge values in linux

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5148,6 +5148,7 @@ static void rib_process_dplane_results(struct event *event)
 			case DPLANE_OP_INTF_UPDATE:
 			case DPLANE_OP_INTF_DELETE:
 			case DPLANE_OP_INTF_NETCONFIG:
+			case DPLANE_OP_INTF_SPEED_GET:
 				zebra_if_dplane_result(ctx);
 				break;
 

--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -424,6 +424,7 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_TC_FILTER_UPDATE:
 		/* Not currently handled */
 	case DPLANE_OP_INTF_NETCONFIG: /*NYI*/
+	case DPLANE_OP_INTF_SPEED_GET:
 	case DPLANE_OP_SRV6_ENCAP_SRCADDR_SET:
 	case DPLANE_OP_NONE:
 	case DPLANE_OP_STARTUP_STAGE:


### PR DESCRIPTION
Add dplane ctx helpers to carry interface speed and skip ethtool polling when the dataplane provides a value. Avoid scheduling speed update timers in this case.

Original PR19412 by maxime-leroy
