### PR TITLE
zebra: clean up VRF handling by using dataplane provided vrf_id

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1503,32 +1503,28 @@ static void zebra_if_netconf_update_ctx(struct zebra_dplane_ctx *ctx,
 			(*linkdown_set ? "ON" : "OFF"));
 }
 
-static void interface_vrf_change(enum dplane_op_e op, ifindex_t ifindex,
-				 const char *name, uint32_t tableid,
-				 ns_id_t ns_id)
+static void interface_vrf_change(enum dplane_op_e op, vrf_id_t vrf_id, const char *name,
+				 uint32_t tableid, ns_id_t ns_id)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf = NULL;
 
 	if (op == DPLANE_OP_INTF_DELETE) {
 		if (IS_ZEBRA_DEBUG_DPLANE)
-			zlog_debug("DPLANE_OP_INTF_DELETE for VRF %s(%u)", name,
-				   ifindex);
+			zlog_debug("DPLANE_OP_INTF_DELETE for VRF %s(%u)", name, vrf_id);
 
-		vrf = vrf_lookup_by_id((vrf_id_t)ifindex);
+		vrf = vrf_lookup_by_id(vrf_id);
 		if (!vrf) {
-			flog_warn(EC_ZEBRA_VRF_NOT_FOUND,
-				  "%s(%u): vrf not found", name, ifindex);
+			flog_warn(EC_ZEBRA_VRF_NOT_FOUND, "%s(%u): vrf not found", name, vrf_id);
 			return;
 		}
 
-		frrtrace(4, frr_zebra, if_vrf_change, ifindex, name, tableid, 0);
+		frrtrace(4, frr_zebra, if_vrf_change, vrf_id, name, tableid, 0);
 		vrf_delete(vrf);
 	} else {
 		if (IS_ZEBRA_DEBUG_DPLANE)
-			zlog_debug(
-				"DPLANE_OP_INTF_UPDATE for VRF %s(%u) table %u",
-				name, ifindex, tableid);
+			zlog_debug("DPLANE_OP_INTF_UPDATE for VRF %s(%u) table %u", name, vrf_id,
+				   tableid);
 
 		/*
 		 * For a given tableid, if there already exists a vrf and it
@@ -1540,26 +1536,24 @@ static void interface_vrf_change(enum dplane_op_e op, ifindex_t ifindex,
 		if (exist_id != VRF_DEFAULT || strmatch(name, VRF_DEFAULT_NAME)) {
 			vrf = vrf_lookup_by_id(exist_id);
 
-			if (!vrf_lookup_by_id((vrf_id_t)ifindex) && !vrf) {
-				flog_err(EC_ZEBRA_VRF_NOT_FOUND,
-					 "VRF %s id %u does not exist", name,
-					 ifindex);
+			if (!vrf_lookup_by_id(vrf_id) && !vrf) {
+				flog_err(EC_ZEBRA_VRF_NOT_FOUND, "VRF %s id %u does not exist",
+					 name, vrf_id);
 				frr_exit_with_buffer_flush(-1);
 			}
 
 			if (vrf && strcmp(name, vrf->name)) {
 				flog_err(EC_ZEBRA_VRF_MISCONFIGURED,
 					 "VRF %s id %u table id overlaps existing vrf %s(%d), misconfiguration exiting",
-					 name, ifindex, vrf->name, vrf->vrf_id);
+					 name, vrf_id, vrf->name, vrf->vrf_id);
 				frr_exit_with_buffer_flush(-1);
 			}
 		}
 
-		frrtrace(4, frr_zebra, if_vrf_change, ifindex, name, tableid, 1);
-		vrf = vrf_update((vrf_id_t)ifindex, name);
+		frrtrace(4, frr_zebra, if_vrf_change, vrf_id, name, tableid, 1);
+		vrf = vrf_update(vrf_id, name);
 		if (!vrf) {
-			flog_err(EC_LIB_INTERFACE, "VRF %s id %u not created",
-				 name, ifindex);
+			flog_err(EC_LIB_INTERFACE, "VRF %s id %u not created", name, vrf_id);
 			return;
 		}
 
@@ -1580,9 +1574,7 @@ static void interface_vrf_change(enum dplane_op_e op, ifindex_t ifindex,
 
 		/* Enable the created VRF. */
 		if (!vrf_enable(vrf)) {
-			flog_err(EC_LIB_INTERFACE,
-				 "Failed to enable VRF %s id %u", name,
-				 ifindex);
+			flog_err(EC_LIB_INTERFACE, "Failed to enable VRF %s id %u", name, vrf_id);
 			return;
 		}
 	}
@@ -2020,13 +2012,13 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		if_delete_update(&ifp);
 
 		if (vrf)
-			interface_vrf_change(op, ifindex, name, vrf->data.l.table_id, ns_id);
+			interface_vrf_change(op, vrf->vrf_id, name, vrf->data.l.table_id, ns_id);
 	} else {
 		ifindex_t master_ifindex, bridge_ifindex, link_ifindex;
+		vrf_id_t vrf_id = dplane_ctx_get_ifp_vrf_id(ctx);
 		enum zebra_slave_iftype zif_slave_type;
 		uint8_t bypass;
 		uint64_t flags;
-		vrf_id_t vrf_id;
 		uint32_t mtu;
 		ns_id_t link_nsid;
 		struct zebra_if *zif;
@@ -2041,7 +2033,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns()) {
 			uint32_t tableid = dplane_ctx_get_ifp_table_id(ctx);
 
-			interface_vrf_change(op, ifindex, name, tableid, ns_id);
+			interface_vrf_change(op, vrf_id, name, tableid, ns_id);
 		}
 
 		master_ifindex = dplane_ctx_get_ifp_master_ifindex(ctx);
@@ -2050,7 +2042,6 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		bond_ifindex = dplane_ctx_get_ifp_bond_ifindex(ctx);
 		bypass = dplane_ctx_get_ifp_bypass(ctx);
 		flags = dplane_ctx_get_ifp_flags(ctx);
-		vrf_id = dplane_ctx_get_ifp_vrf_id(ctx);
 		mtu = dplane_ctx_get_ifp_mtu(ctx);
 		link_ifindex = dplane_ctx_get_ifp_link_ifindex(ctx);
 		link_nsid = dplane_ctx_get_ifp_link_nsid(ctx);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1503,23 +1503,17 @@ static void zebra_if_netconf_update_ctx(struct zebra_dplane_ctx *ctx,
 			(*linkdown_set ? "ON" : "OFF"));
 }
 
-static void interface_vrf_change(enum dplane_op_e op, vrf_id_t vrf_id, const char *name,
-				 uint32_t tableid, ns_id_t ns_id)
+static void interface_vrf_change(enum dplane_op_e op, struct vrf *vrf, vrf_id_t vrf_id,
+				 const char *name, uint32_t tableid, ns_id_t ns_id)
 {
-	struct vrf *vrf;
 	struct zebra_vrf *zvrf = NULL;
 
 	if (op == DPLANE_OP_INTF_DELETE) {
 		if (IS_ZEBRA_DEBUG_DPLANE)
-			zlog_debug("DPLANE_OP_INTF_DELETE for VRF %s(%u)", name, vrf_id);
+			zlog_debug("DPLANE_OP_INTF_DELETE for VRF %s(%u)", vrf->name, vrf->vrf_id);
 
-		vrf = vrf_lookup_by_id(vrf_id);
-		if (!vrf) {
-			flog_warn(EC_ZEBRA_VRF_NOT_FOUND, "%s(%u): vrf not found", name, vrf_id);
-			return;
-		}
-
-		frrtrace(4, frr_zebra, if_vrf_change, vrf_id, name, tableid, 0);
+		frrtrace(4, frr_zebra, if_vrf_change, vrf->vrf_id, vrf->name, vrf->data.l.table_id,
+			 0);
 		vrf_delete(vrf);
 	} else {
 		if (IS_ZEBRA_DEBUG_DPLANE)
@@ -2012,7 +2006,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		if_delete_update(&ifp);
 
 		if (vrf)
-			interface_vrf_change(op, vrf->vrf_id, name, vrf->data.l.table_id, ns_id);
+			interface_vrf_change(op, vrf, 0, NULL, 0, ns_id);
 	} else {
 		ifindex_t master_ifindex, bridge_ifindex, link_ifindex;
 		vrf_id_t vrf_id = dplane_ctx_get_ifp_vrf_id(ctx);
@@ -2033,7 +2027,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns()) {
 			uint32_t tableid = dplane_ctx_get_ifp_table_id(ctx);
 
-			interface_vrf_change(op, vrf_id, name, tableid, ns_id);
+			interface_vrf_change(op, NULL, vrf_id, name, tableid, ns_id);
 		}
 
 		master_ifindex = dplane_ctx_get_ifp_master_ifindex(ctx);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1976,7 +1976,6 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 	ns_id_t ns_id = dplane_ctx_get_ns_id(ctx);
 	ifindex_t ifindex = dplane_ctx_get_ifindex(ctx);
 	ifindex_t bond_ifindex = dplane_ctx_get_ifp_bond_ifindex(ctx);
-	uint32_t tableid = dplane_ctx_get_ifp_table_id(ctx);
 	enum zebra_iftype zif_type = dplane_ctx_get_ifp_zif_type(ctx);
 	struct interface *ifp;
 	struct zebra_ns *zns;
@@ -1992,6 +1991,8 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 
 	ifp = if_lookup_by_name_per_ns(zns, name);
 	if (op == DPLANE_OP_INTF_DELETE) {
+		struct vrf *vrf = NULL;
+
 		/* Delete interface notification from kernel */
 		if (ifp == NULL) {
 			if (IS_ZEBRA_DEBUG_EVENT)
@@ -2013,10 +2014,13 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		else if (IS_ZEBRA_IF_VXLAN(ifp))
 			zebra_l2_vxlanif_del(ifp);
 
+		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns())
+			vrf = ifp->vrf;
+
 		if_delete_update(&ifp);
 
-		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns())
-			interface_vrf_change(op, ifindex, name, tableid, ns_id);
+		if (vrf)
+			interface_vrf_change(op, ifindex, name, vrf->data.l.table_id, ns_id);
 	} else {
 		ifindex_t master_ifindex, bridge_ifindex, link_ifindex;
 		enum zebra_slave_iftype zif_slave_type;
@@ -2034,8 +2038,11 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		uint64_t change_flags;
 
 		/* If VRF, create or update the VRF structure itself. */
-		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns())
+		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns()) {
+			uint32_t tableid = dplane_ctx_get_ifp_table_id(ctx);
+
 			interface_vrf_change(op, ifindex, name, tableid, ns_id);
+		}
 
 		master_ifindex = dplane_ctx_get_ifp_master_ifindex(ctx);
 		zif_slave_type = dplane_ctx_get_ifp_zif_slave_type(ctx);

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -91,9 +91,9 @@ TRACEPOINT_LOGLEVEL(frr_zebra, if_upd_ctx_dplane_result, TRACE_INFO)
 TRACEPOINT_EVENT(
 	frr_zebra,
 	if_vrf_change,
-	TP_ARGS(ifindex_t, ifindex, const char *, name, uint32_t, tableid, uint8_t, loc),
+	TP_ARGS(vrf_id_t, vrf_id, const char *, name, uint32_t, tableid, uint8_t, loc),
 	TP_FIELDS(
-		ctf_integer(ifindex_t, ifindex, ifindex)
+		ctf_integer(vrf_id_t, vrf_id, vrf_id)
 		ctf_string(vrf_name, name)
 		ctf_integer(uint32_t, tableid, tableid)
 		ctf_integer(uint8_t, location, loc)


### PR DESCRIPTION
Zebra was implicitly assuming that the VRF netdevice ifindex could be used as the VRF identifier, leading to casts from ifindex to vrf_id_t. While this works with the Linux kernel dataplane, it does not respect the dataplane API, which exposes these identifiers as distinct concepts.

The code is updated to use the VRF identifier explicitly provided by the dataplane context and removes the need for casting ifindex to vrf_id_t. In addition, the VRF delete path is clarified by no longer reading unused dataplane fields, avoiding confusion about which identifiers are actually required.

There is no behavior change for the Linux kernel dataplane.

Original PR20318 by maxime-leroy
