### PR TITLE
zebra: fix upon detach vxlan interface, bridge present in zevpn ctx

### DIFF
--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -327,6 +327,7 @@ static int zebra_vxlan_if_update_vni(struct interface *ifp,
 			zebra_evpn_neigh_del_all(zevpn, 1, 0, DEL_ALL_NEIGH, NULL);
 			zebra_evpn_mac_del_all(zevpn, 1, 0, DEL_ALL_MAC, NULL);
 			zebra_evpn_vtep_del_all(zevpn, 1, NULL);
+			zevpn_bridge_if_set(zevpn, zevpn->bridge_if, false /* unset */);
 			return 0;
 		}
 


### PR DESCRIPTION
In an evpn context, when detaching a vxlan interface from a bridged interface, then the context remains with the bridged interface:

> ip link set dev vxlan101 nomaster
> [..]
> PE1# show evpn vni
> VNI        Type VxLAN IF              # MACs   # ARPs   # Remote VTEPs  Tenant VRF      VLAN       BRIDGE
> 101        L2   vxlan101              0        0        0               default         1          br101

Fix this by removing the bridge pointer.

Fixes: b7cfce934fc0 ("zebra, lib: zebra changes for symmetric routing support")

Original PR20974 by lsang6WIND
