### PR TITLE
greptile: Reduce ruleset to memory-allocation, logging-api, and string-safety

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -20,6 +20,11 @@
     "collapsible": true,
     "defaultOpen": false
   },
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
   "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback.",
   "rules": [
     {


### PR DESCRIPTION
config.json details

Settings:
- Strictness 2, status check enabled, re-reviews on every push
- Comment types: logic, syntax, best_practices, security

Rule structure:
Each rule has an id, description, scope, and severity.
- Scope: glob patterns that limit which files the rule applies to (e.g. **/*.c, **/*.yang, lib/**)
- Severity: high (P0/P1 — must fix), medium (P2 — should fix), low (NOTE — suggestion)

Rules cover:
- Memory safety: XMALLOC/XCALLOC/XFREE enforcement, no raw malloc/free
- String safety: no strcpy/strcat/sprintf, enforce strlcpy/snprintf
- Banned functions: no system(), no fork()+exec()
  - Added popen() to banned-functions rule (same issue with SIGINT to be ignored and break daemon shutdown)
- Typesafe containers: reject legacy linklist.h/hash.h, enforce lib/typesafe.h
- CLI conventions: DEFPY required, YANG model required for YANGified daemons
- YANG/northbound: API-agnostic callbacks, JSON output backed by YANG models
- Packet parsing: bounds checking on all network message parsing
- RCU safety: lock discipline, no direct XFREE on RCU-protected data
- Logging: zlog_* only, debug guarded by CLI flags
- Licensing: SPDX headers, GPL compatibility checks
- Formatting: include order, whitespace discipline, printfrr usage
- Commit messages: subsystem prefix, imperative mood, Signed-off-by
- Topotest coverage (P0): blocks merge if daemon code changes without tests/topotests/ changes
- User docs (P0): blocks merge if CLI/YANG changes without doc/user/ updates
  - Mark User docs as Prority 1 checks to run first
  - Flag doc updates as mandatory for features
- Topotest coverage: check for coverage as priority 2 (after used docs)
  - Flag Topotests coverage as mandatory for features