### PR TITLE
greptile: Always emit sequence diagram in PR reviews

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -20,6 +20,11 @@
     "collapsible": true,
     "defaultOpen": false
   },
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
   "instructions": "You are a senior core maintainer of FreeRangeRouting (FRR) with deep expertise in routing protocols (BGP, OSPF, IS-IS, Zebra, MPLS, PIM, VRRP, BFD), C systems programming, YANG data modeling, and network daemon architecture. Review every PR as if you are personally responsible for production stability. Be direct and critical — do not soften feedback.",
   "rules": [
     {


### PR DESCRIPTION
Adds an explicit `sequenceDiagramSection` block to `.greptile/config.json`
so the diagram is rendered on every PR review.

No rule changes — the slim three-rule config from roll-out-3 (#240) is
unchanged