### PR TITLE
greptile: edit severity level to critical in string-safety

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,10 +1,23 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "syntax", "style"],
+  "commentTypes": [
+    "logic",
+    "syntax",
+    "style"
+  ],
   "triggerOnUpdates": true,
   "statusCheck": true,
-  "ignorePatterns": ["**/*.generated.*", "**/*.pb.cc", "**/*.pb.h", "**/*.grpc.pb.cc", "**/*.grpc.pb.h", ".git/**"],
-  "excludeAuthors": ["dependabot[bot]"],
+  "ignorePatterns": [
+    "**/*.generated.*",
+    "**/*.pb.cc",
+    "**/*.pb.h",
+    "**/*.grpc.pb.cc",
+    "**/*.grpc.pb.h",
+    ".git/**"
+  ],
+  "excludeAuthors": [
+    "dependabot[bot]"
+  ],
   "summarySection": {
     "included": true,
     "collapsible": false,
@@ -30,20 +43,32 @@
     {
       "id": "memory-allocation",
       "rule": "NEVER allow standard malloc(), calloc(), realloc(), or free(). Enforce FRR's XCALLOC, XMALLOC, XREALLOC, XSTRDUP, and XFREE macros (requires MTYPE). Every allocation must use the MTYPE tracking system declared via DECLARE_MTYPE/DEFINE_MTYPE. Prefer DEFINE_MTYPE_STATIC for module-private types.",
-      "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
+      "scope": [
+        "**/*.c",
+        "**/*.h",
+        "**/*.cpp"
+      ],
       "severity": "critical"
     },
     {
       "id": "logging-api",
       "rule": "Reject printf() or stdio logging. Enforce FRR's zlog_* API (zlog_debug, zlog_err, zlog_warn, zlog_info, zlog_notice) and structured error macros flog_err(), flog_warn(), flog_err_sys() (which require an EC_* error-code argument). All debug statements MUST be guarded with CLI-controllable debug flags — unguarded debug prints are unacceptable at scale.",
-      "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
+      "scope": [
+        "**/*.c",
+        "**/*.h",
+        "**/*.cpp"
+      ],
       "severity": "high"
     },
     {
       "id": "string-safety",
       "rule": "strcpy(), strcat(), and sprintf() are strictly FORBIDDEN — no exceptions, even if the buffer cannot currently overflow (a future change may introduce one). Enforce strlcpy(), strlcat(), and snprintf(). Buffer size arguments MUST use sizeof() wherever possible — never hardcoded size constants.",
-      "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
-      "severity": "high"
+      "scope": [
+        "**/*.c",
+        "**/*.h",
+        "**/*.cpp"
+      ],
+      "severity": "critical"
     }
   ],
   "disabledRules": []


### PR DESCRIPTION
 Bump the `string-safety` rule in `.greptile/config.json` from `high` to `critical` 