### PR TITLE
greptile: edit severity level to critical in string-safety

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -43,7 +43,7 @@
       "id": "string-safety",
       "rule": "strcpy(), strcat(), and sprintf() are strictly FORBIDDEN — no exceptions, even if the buffer cannot currently overflow (a future change may introduce one). Enforce strlcpy(), strlcat(), and snprintf(). Buffer size arguments MUST use sizeof() wherever possible — never hardcoded size constants.",
       "scope": ["**/*.c", "**/*.h", "**/*.cpp"],
-      "severity": "high"
+      "severity": "critical"
     }
   ],
   "disabledRules": []


### PR DESCRIPTION
Bump the `string-safety` rule in `.greptile/config.json` from `high` to `critical`